### PR TITLE
Add script to remove fuzzy translations

### DIFF
--- a/.github/workflows/lazarus-compile.yml
+++ b/.github/workflows/lazarus-compile.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
-        operating-system: [windows-latest, ubuntu-latest, macos-latest]
+        operating-system: [windows-latest, ubuntu-latest, macos-13]
         lazarus-versions: [stable]
     
     steps:
@@ -68,7 +68,7 @@ jobs:
       run: make
 
     - name: Build the MacOS Application
-      if: ${{ matrix.operating-system == 'macos-latest' }}
+      if: ${{ matrix.operating-system == 'macos-13' }}
       run: lazbuild -B src/bgrabitmap/bgrabitmap/bgrabitmappack.lpk && lazbuild -B src/metadarkstyle/metadarkstyle.lpk && lazbuild -B src/Cantara.lpi
 
     # --- PACKAGING WITH DYNAMIC NAMES ---
@@ -99,7 +99,7 @@ jobs:
         path: cantara.iss
 
     - name: Zip MacOS Application
-      if: ${{ matrix.operating-system == 'macos-latest' }}
+      if: ${{ matrix.operating-system == 'macos-13' }}
       run: zip -r cantara-${{ env.REL_VER }}-macos-x64.zip src/cantara.app COPYING
 
 
@@ -124,7 +124,7 @@ jobs:
           Output/*.exe
 
     - name: Upload MacOS Artifacts
-      if: ${{ matrix.operating-system == 'macos-latest' }}
+      if: ${{ matrix.operating-system == 'macos-13' }}
       uses: actions/upload-artifact@v4
       with:
         name: cantara-${{ env.REL_VER }}-macos

--- a/remove_fuzzy.sh
+++ b/remove_fuzzy.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+#
+# remove_fuzzy.sh - Entfernt alle fuzzy-Markierungen aus PO-Dateien
+#
+# Verwendung: ./remove_fuzzy.sh [Pfad zu PO-Dateien]
+# Beispiel:   ./remove_fuzzy.sh ./src/locals/
+#
+# Das Skript entfernt:
+#   - "#, fuzzy"-Zeilen
+#   - "#| ..."-Zeilen (alte Originaltexte nach fuzzy)
+# Und aktualisiert Last-Translator und PO-Revision-Date.
+#
+
+set -e
+
+AUTHOR_NAME="Jan Martin Reckel"
+AUTHOR_EMAIL="jm.reckel@t-online.de"
+
+# Pfad zu den PO-Dateien (Standard: aktuelles Verzeichnis)
+PO_DIR="${1:-.}"
+
+# Prüfen ob Verzeichnis existiert
+if [ ! -d "$PO_DIR" ]; then
+    echo "Fehler: Verzeichnis '$PO_DIR' existiert nicht."
+    exit 1
+fi
+
+# Alle PO-Dateien finden
+mapfile -t PO_FILES < <(find "$PO_DIR" -name "*.po" -type f)
+
+if [ ${#PO_FILES[@]} -eq 0 ]; then
+    echo "Keine PO-Dateien in '$PO_DIR' gefunden."
+    exit 0
+fi
+
+echo "Verarbeite PO-Dateien in: $PO_DIR"
+echo "Autor: $AUTHOR_NAME <$AUTHOR_EMAIL>"
+echo ""
+
+PROCESSED=0
+
+for PO_FILE in "${PO_FILES[@]}"; do
+    echo "Verarbeite: $PO_FILE"
+    
+    # Temporäre Datei für die Bearbeitung
+    TEMP_FILE=$(mktemp)
+    
+    # Zähler für entfernte fuzzy-Markierungen
+    FUZZY_COUNT=0
+    
+    # Status: befinden wir uns in einem fuzzy-Block?
+    IN_FUZZY_BLOCK=0
+    
+    # Datei zeilenweise verarbeiten
+    while IFS= read -r line || [ -n "$line" ]; do
+        # Prüfen ob dies eine fuzzy-Markierung ist
+        if [[ "$line" == "#, fuzzy" ]]; then
+            IN_FUZZY_BLOCK=1
+            FUZZY_COUNT=$((FUZZY_COUNT + 1))
+            continue
+        fi
+        
+        # Wenn wir in einem fuzzy-Block sind, prüfe auf #| Kommentarzeilen
+        if [ $IN_FUZZY_BLOCK -eq 1 ]; then
+            # Prüfen ob dies eine #| Zeile ist (alter Originaltext)
+            if [[ "$line" == "#|"* ]]; then
+                # Diese Zeile überspringen (nicht zur Ausgabe hinzufügen)
+                continue
+            fi
+            
+            # Wir sind am Ende des fuzzy-Blocks
+            IN_FUZZY_BLOCK=0
+        fi
+        
+        # Normale Zeile zur Ausgabe hinzufügen
+        echo "$line" >> "$TEMP_FILE"
+        
+    done < "$PO_FILE"
+    
+    # Wenn fuzzy-Markierungen entfernt wurden, aktualisiere Metadaten
+    if [ $FUZZY_COUNT -gt 0 ]; then
+        # Erstelle weitere temporäre Datei für Metadaten-Update
+        TEMP_FILE2=$(mktemp)
+        
+        CURRENT_DATE=$(date +"%Y-%m-%d %H:%M")
+        
+        # Metadaten aktualisieren
+        while IFS= read -r line || [ -n "$line" ]; do
+            # Last-Translator aktualisieren
+            if [[ "$line" == "\"Last-Translator:"* ]]; then
+                echo "\"Last-Translator: $AUTHOR_NAME <$AUTHOR_EMAIL>\\n\"" >> "$TEMP_FILE2"
+                continue
+            fi
+            
+            # PO-Revision-Date aktualisieren
+            if [[ "$line" == "\"PO-Revision-Date:"* ]]; then
+                echo "\"PO-Revision-Date: $CURRENT_DATE\\n\"" >> "$TEMP_FILE2"
+                continue
+            fi
+            
+            # Normale Zeile übernehmen
+            echo "$line" >> "$TEMP_FILE2"
+            
+        done < "$TEMP_FILE"
+        
+        # Temporäre Datei ersetzen
+        mv "$TEMP_FILE2" "$PO_FILE"
+        rm -f "$TEMP_FILE"
+        
+        echo "  -> $FUZZY_COUNT fuzzy-Markierung(en) entfernt"
+        PROCESSED=$((PROCESSED + 1))
+    else
+        rm -f "$TEMP_FILE"
+    fi
+    
+done
+
+echo ""
+echo "Fertig! $PROCESSED Datei(en) wurden aktualisiert."

--- a/src/Cantara.lpi
+++ b/src/Cantara.lpi
@@ -41,7 +41,7 @@
       <MajorVersionNr Value="2"/>
       <MinorVersionNr Value="7"/>
       <RevisionNr Value="1"/>
-      <BuildNr Value="1"/>
+      <BuildNr Value="3"/>
       <Language Value="0809"/>
       <CharSet Value="04B0"/>
       <StringTable Comments="Open Source Song Presenter Software" CompanyName="Jan Martin Reckel" LegalCopyright="Jan Martin Reckel" ProductName="Cantara" ProductVersion="2.7.1"/>

--- a/src/forms/formsongstyle.lrj
+++ b/src/forms/formsongstyle.lrj
@@ -1,0 +1,20 @@
+{"version":1,"strings":[
+{"hash":225406261,"name":"tfrmsongstyle.caption","sourcebytes":[83,111,110,103,32,83,116,121,108,101,32,79,118,101,114,114,105,100,101],"value":"Song Style Override"},
+{"hash":15725175,"name":"tfrmsongstyle.cbusecustomstyle.caption","sourcebytes":[85,115,101,32,99,117,115,116,111,109,32,115,116,121,108,101,32,102,111,114,32,116,104,105,115,32,115,111,110,103],"value":"Use custom style for this song"},
+{"hash":29072226,"name":"tfrmsongstyle.gbfont.caption","sourcebytes":[70,111,110,116,32,38,38,32,84,101,120,116,32,67,111,108,111,117,114],"value":"Font && Text Colour"},
+{"hash":26137854,"name":"tfrmsongstyle.btnfont.caption","sourcebytes":[83,101,108,101,99,116,32,102,111,110,116,46,46,46],"value":"Select font..."},
+{"hash":180195476,"name":"tfrmsongstyle.lblfontpreview.caption","sourcebytes":[65,114,105,97,108,44,32,50,52,32,112,116],"value":"Arial, 24 pt"},
+{"hash":235903546,"name":"tfrmsongstyle.lbltextcolorlabel.caption","sourcebytes":[84,101,120,116,32,99,111,108,111,117,114,58],"value":"Text colour:"},
+{"hash":32370148,"name":"tfrmsongstyle.gbbackground.caption","sourcebytes":[66,97,99,107,103,114,111,117,110,100],"value":"Background"},
+{"hash":97553370,"name":"tfrmsongstyle.lblbgcolorlabel.caption","sourcebytes":[66,97,99,107,103,114,111,117,110,100,32,99,111,108,111,117,114,58],"value":"Background colour:"},
+{"hash":17924581,"name":"tfrmsongstyle.cbshowbgimage.caption","sourcebytes":[83,104,111,119,32,98,97,99,107,103,114,111,117,110,100,32,105,109,97,103,101],"value":"Show background image"},
+{"hash":5671610,"name":"tfrmsongstyle.lblbgimagelabel.caption","sourcebytes":[80,97,116,104,58],"value":"Path:"},
+{"hash":115952286,"name":"tfrmsongstyle.btnbrowsebgimage.caption","sourcebytes":[66,114,111,119,115,101,46,46,46],"value":"Browse..."},
+{"hash":8496090,"name":"tfrmsongstyle.lbltransparency.caption","sourcebytes":[84,114,97,110,115,112,97,114,101,110,99,121,32,40,37,41,58],"value":"Transparency (%):"},
+{"hash":55340756,"name":"tfrmsongstyle.gbalign.caption","sourcebytes":[72,111,114,105,122,111,110,116,97,108,32,65,108,105,103,110,109,101,110,116],"value":"Horizontal Alignment"},
+{"hash":240600970,"name":"tfrmsongstyle.lblalignlabel.caption","sourcebytes":[65,108,105,103,110,109,101,110,116,58],"value":"Alignment:"},
+{"hash":126668695,"name":"tfrmsongstyle.gbpreview.caption","sourcebytes":[80,114,101,118,105,101,119],"value":"Preview"},
+{"hash":264711028,"name":"tfrmsongstyle.btnreset.caption","sourcebytes":[82,101,115,101,116,32,116,111,32,103,108,111,98,97,108,32,100,101,102,97,117,108,116],"value":"Reset to global default"},
+{"hash":1339,"name":"tfrmsongstyle.btnok.caption","sourcebytes":[79,75],"value":"OK"},
+{"hash":77089212,"name":"tfrmsongstyle.btncancel.caption","sourcebytes":[67,97,110,99,101,108],"value":"Cancel"}
+]}

--- a/src/forms/present.lfm
+++ b/src/forms/present.lfm
@@ -8,16 +8,16 @@ object frmPresent: TfrmPresent
   ClientHeight = 535
   ClientWidth = 1070
   Color = clBlack
+  PopupMenu = PresentationMenu
+  Position = poScreenCenter
+  LCLVersion = '4.6.0.0'
+  WindowState = wsMaximized
   OnCreate = FormCreate
   OnDestroy = FormDestroy
   OnHide = FormHide
   OnKeyDown = FormKeyDown
   OnResize = FormResize
   OnShow = FormShow
-  PopupMenu = PresentationMenu
-  Position = poScreenCenter
-  LCLVersion = '3.2.0.0'
-  WindowState = wsMaximized
   object imageShower: TImage
     AnchorSideLeft.Control = Owner
     AnchorSideTop.Control = Owner
@@ -31,8 +31,8 @@ object frmPresent: TfrmPresent
     Width = 1070
     AntialiasingMode = amOn
     Align = alClient
-    OnClick = imageShowerClick
     Proportional = True
+    OnClick = imageShowerClick
   end
   object PresentationMenu: TPopupMenu
     Left = 191

--- a/src/forms/present.pas
+++ b/src/forms/present.pas
@@ -217,7 +217,10 @@ end;
 procedure TfrmPresent.FormShow(Sender: TObject);
 begin
   if frmSettings.GetHideCursorInPresentation then
+  begin
     Self.Cursor := crNone;
+    imageShower.Cursor := crNone;
+  end;
   PresentationCanvas.LoadBackgroundBitmap;
   if SlideList.Count > 0 then showItem(0)
   else
@@ -371,7 +374,10 @@ begin
   if csDestroying in ComponentState then Exit;
 
   if Self.Cursor = crNone then
+  begin
     Self.Cursor := crDefault;
+    imageShower.Cursor := crDefault;
+  end;
   BlackScreenActive := False;
   if Assigned(FadeTimer) and FadeTimer.Enabled then
   begin
@@ -430,12 +436,16 @@ begin
     ShowWindow(Handle, SW_SHOWFULLSCREEN);
     Fullscreen := True;
     if frmSettings.GetHideCursorInPresentation then
-       Self.Cursor := crNone;
+    begin
+      Self.Cursor := crNone;
+      imageShower.Cursor := crNone;
+    end;
   end else begin
     // From full screen
     ShowWindow(Handle, SW_SHOWMAXIMIZED);
     Fullscreen := False;
-    Self.Cursor:=crDefault;
+    Self.Cursor := crDefault;
+    imageShower.Cursor := crDefault;
   end;
   {$endif}
   MenuItemToggleFullScreen.Checked:=Fullscreen;
@@ -473,12 +483,16 @@ begin
     ShowWindow(Handle, SW_SHOWFULLSCREEN);
     Fullscreen := True;
     if frmSettings.GetHideCursorInPresentation then
-       Self.Cursor := crNone;
+    begin
+      Self.Cursor := crNone;
+      imageShower.Cursor := crNone;
+    end;
   end else begin
     // From full screen
     ShowWindow(Handle, SW_SHOWMAXIMIZED);
     Fullscreen := False;
-    Self.Cursor:=crDefault;
+    Self.Cursor := crDefault;
+    imageShower.Cursor := crDefault;
   end;
   {$endif}
   MenuItemToggleFullScreen.Checked:=Fullscreen;

--- a/src/forms/present.pas
+++ b/src/forms/present.pas
@@ -216,6 +216,8 @@ end;
 
 procedure TfrmPresent.FormShow(Sender: TObject);
 begin
+  if frmSettings.GetHideCursorInPresentation then
+    Self.Cursor := crNone;
   PresentationCanvas.LoadBackgroundBitmap;
   if SlideList.Count > 0 then showItem(0)
   else
@@ -368,6 +370,8 @@ begin
   // PresentationCanvas, SlideList, etc., so touching them would crash.
   if csDestroying in ComponentState then Exit;
 
+  if Self.Cursor = crNone then
+    Self.Cursor := crDefault;
   BlackScreenActive := False;
   if Assigned(FadeTimer) and FadeTimer.Enabled then
   begin

--- a/src/forms/present.pas
+++ b/src/forms/present.pas
@@ -435,17 +435,10 @@ begin
     // To full screen
     ShowWindow(Handle, SW_SHOWFULLSCREEN);
     Fullscreen := True;
-    if frmSettings.GetHideCursorInPresentation then
-    begin
-      Self.Cursor := crNone;
-      imageShower.Cursor := crNone;
-    end;
   end else begin
     // From full screen
     ShowWindow(Handle, SW_SHOWMAXIMIZED);
     Fullscreen := False;
-    Self.Cursor := crDefault;
-    imageShower.Cursor := crDefault;
   end;
   {$endif}
   MenuItemToggleFullScreen.Checked:=Fullscreen;
@@ -482,17 +475,10 @@ begin
     // To full screen
     ShowWindow(Handle, SW_SHOWFULLSCREEN);
     Fullscreen := True;
-    if frmSettings.GetHideCursorInPresentation then
-    begin
-      Self.Cursor := crNone;
-      imageShower.Cursor := crNone;
-    end;
   end else begin
     // From full screen
     ShowWindow(Handle, SW_SHOWMAXIMIZED);
     Fullscreen := False;
-    Self.Cursor := crDefault;
-    imageShower.Cursor := crDefault;
   end;
   {$endif}
   MenuItemToggleFullScreen.Checked:=Fullscreen;

--- a/src/forms/present.pas
+++ b/src/forms/present.pas
@@ -429,10 +429,13 @@ begin
     // To full screen
     ShowWindow(Handle, SW_SHOWFULLSCREEN);
     Fullscreen := True;
+    if frmSettings.GetHideCursorInPresentation then
+       Self.Cursor := crNone;
   end else begin
     // From full screen
     ShowWindow(Handle, SW_SHOWMAXIMIZED);
     Fullscreen := False;
+    Self.Cursor:=crDefault;
   end;
   {$endif}
   MenuItemToggleFullScreen.Checked:=Fullscreen;
@@ -469,10 +472,13 @@ begin
     // To full screen
     ShowWindow(Handle, SW_SHOWFULLSCREEN);
     Fullscreen := True;
+    if frmSettings.GetHideCursorInPresentation then
+       Self.Cursor := crNone;
   end else begin
     // From full screen
     ShowWindow(Handle, SW_SHOWMAXIMIZED);
     Fullscreen := False;
+    Self.Cursor:=crDefault;
   end;
   {$endif}
   MenuItemToggleFullScreen.Checked:=Fullscreen;

--- a/src/forms/settings.lfm
+++ b/src/forms/settings.lfm
@@ -138,8 +138,20 @@ object frmSettings: TfrmSettings
     Caption = 'ms'
     ParentFont = False
   end
-  object gbPresentation: TGroupBox
+  object cbHideCursorInPresentation: TCheckBox
+    AnchorSideLeft.Control = gbPresentation
     AnchorSideTop.Control = seFadeDuration
+    AnchorSideTop.Side = asrBottom
+    Left = 8
+    Height = 26
+    Top = 143
+    Width = 330
+    Caption = 'Hide mouse cursor in presentation mode'
+    ParentFont = False
+    TabOrder = 14
+  end
+  object gbPresentation: TGroupBox
+    AnchorSideTop.Control = cbHideCursorInPresentation
     AnchorSideTop.Side = asrBottom
     AnchorSideBottom.Control = btnClose
     Left = 8

--- a/src/forms/settings.lfm
+++ b/src/forms/settings.lfm
@@ -8,7 +8,7 @@ object frmSettings: TfrmSettings
   ClientHeight = 648
   ClientWidth = 939
   Position = poScreenCenter
-  LCLVersion = '4.4.0.0'
+  LCLVersion = '4.6.0.0'
   OnClose = FormClose
   OnCloseQuery = FormCloseQuery
   OnCreate = FormCreate
@@ -20,7 +20,7 @@ object frmSettings: TfrmSettings
     AnchorSideTop.Side = asrCenter
     Left = 8
     Height = 21
-    Top = 12
+    Top = 15
     Width = 116
     Caption = 'Song Repo Path:'
     Layout = tlCenter
@@ -31,7 +31,7 @@ object frmSettings: TfrmSettings
     AnchorSideLeft.Control = labelSongDir
     AnchorSideLeft.Side = asrBottom
     Left = 129
-    Height = 28
+    Height = 34
     Top = 8
     Width = 781
     Anchors = [akTop, akLeft, akRight]
@@ -45,7 +45,7 @@ object frmSettings: TfrmSettings
     AnchorSideTop.Side = asrCenter
     Left = 912
     Height = 23
-    Top = 11
+    Top = 14
     Width = 24
     Anchors = [akTop, akRight]
     Caption = '...'
@@ -58,8 +58,8 @@ object frmSettings: TfrmSettings
     AnchorSideTop.Control = edtRepoPath
     AnchorSideTop.Side = asrBottom
     Left = 8
-    Height = 26
-    Top = 36
+    Height = 25
+    Top = 42
     Width = 216
     Caption = 'Empty slide between songs'
     Checked = True
@@ -73,8 +73,8 @@ object frmSettings: TfrmSettings
     AnchorSideTop.Control = cbEmptyFrame
     AnchorSideTop.Side = asrBottom
     Left = 8
-    Height = 26
-    Top = 62
+    Height = 25
+    Top = 67
     Width = 296
     Caption = 'Show black screen when slide is empty'
     ParentFont = False
@@ -86,8 +86,8 @@ object frmSettings: TfrmSettings
     AnchorSideTop.Control = cbBlackScreenOnEmpty
     AnchorSideTop.Side = asrBottom
     Left = 8
-    Height = 26
-    Top = 88
+    Height = 25
+    Top = 92
     Width = 137
     Caption = 'Spoil next slides'
     Checked = True
@@ -101,8 +101,8 @@ object frmSettings: TfrmSettings
     AnchorSideTop.Control = cbSpoiler
     AnchorSideTop.Side = asrBottom
     Left = 8
-    Height = 26
-    Top = 114
+    Height = 25
+    Top = 117
     Width = 238
     Caption = 'Fade transition between slides'
     ParentFont = False
@@ -115,8 +115,8 @@ object frmSettings: TfrmSettings
     AnchorSideTop.Control = cbSpoiler
     AnchorSideTop.Side = asrBottom
     Left = 254
-    Height = 29
-    Top = 114
+    Height = 34
+    Top = 117
     Width = 70
     BorderSpacing.Left = 8
     Enabled = False
@@ -132,7 +132,7 @@ object frmSettings: TfrmSettings
     AnchorSideTop.Side = asrCenter
     Left = 329
     Height = 21
-    Top = 118
+    Top = 124
     Width = 22
     BorderSpacing.Left = 5
     Caption = 'ms'
@@ -143,26 +143,26 @@ object frmSettings: TfrmSettings
     AnchorSideTop.Control = seFadeDuration
     AnchorSideTop.Side = asrBottom
     Left = 8
-    Height = 26
-    Top = 143
-    Width = 330
+    Height = 25
+    Top = 151
+    Width = 313
     Caption = 'Hide mouse cursor in presentation mode'
     ParentFont = False
-    TabOrder = 14
+    TabOrder = 9
   end
   object gbPresentation: TGroupBox
     AnchorSideTop.Control = cbHideCursorInPresentation
     AnchorSideTop.Side = asrBottom
     AnchorSideBottom.Control = btnClose
     Left = 8
-    Height = 452
-    Top = 143
+    Height = 419
+    Top = 176
     Width = 924
     Anchors = [akTop, akLeft, akRight, akBottom]
     BorderSpacing.Bottom = 5
     Caption = 'Presentation View'
-    ClientHeight = 424
-    ClientWidth = 918
+    ClientHeight = 388
+    ClientWidth = 920
     TabOrder = 7
     OnClick = gbPresentationClick
     object btnBackgroundColor: TButton
@@ -170,9 +170,9 @@ object frmSettings: TfrmSettings
       AnchorSideTop.Control = btnFontSizeManually
       AnchorSideTop.Side = asrBottom
       AnchorSideRight.Control = ImagePresentationPreview
-      Left = 372
+      Left = 373
       Height = 23
-      Top = 52
+      Top = 58
       Width = 344
       Anchors = [akTop]
       BorderSpacing.Left = 8
@@ -185,9 +185,9 @@ object frmSettings: TfrmSettings
       AnchorSideLeft.Side = asrBottom
       AnchorSideTop.Control = lblWrapAfter
       AnchorSideRight.Control = ImagePresentationPreview
-      Left = 372
+      Left = 373
       Height = 23
-      Top = 29
+      Top = 35
       Width = 344
       Align = alCustom
       Anchors = [akTop]
@@ -202,9 +202,9 @@ object frmSettings: TfrmSettings
       AnchorSideTop.Control = btnBackgroundColor
       AnchorSideTop.Side = asrBottom
       AnchorSideRight.Control = ImagePresentationPreview
-      Left = 372
+      Left = 373
       Height = 23
-      Top = 75
+      Top = 81
       Width = 344
       Anchors = [akTop]
       BorderSpacing.Left = 8
@@ -218,7 +218,7 @@ object frmSettings: TfrmSettings
       AnchorSideTop.Side = asrBottom
       Left = 8
       Height = 21
-      Top = 147
+      Top = 153
       Width = 119
       BorderSpacing.Top = 5
       Caption = 'Show Meta Data:'
@@ -231,8 +231,8 @@ object frmSettings: TfrmSettings
       AnchorSideTop.Control = cbMetaTitleSlide
       AnchorSideTop.Side = asrBottom
       Left = 156
-      Height = 26
-      Top = 178
+      Height = 25
+      Top = 183
       Width = 106
       BorderSpacing.Left = 10
       BorderSpacing.Top = 5
@@ -249,8 +249,8 @@ object frmSettings: TfrmSettings
       AnchorSideTop.Control = cbMetaDataFirstSlide
       AnchorSideTop.Side = asrBottom
       Left = 156
-      Height = 26
-      Top = 204
+      Height = 25
+      Top = 208
       Width = 103
       BorderSpacing.Left = 10
       Caption = 'at last slide'
@@ -263,7 +263,7 @@ object frmSettings: TfrmSettings
       AnchorSideTop.Side = asrBottom
       Left = 8
       Height = 21
-      Top = 235
+      Top = 238
       Width = 138
       BorderSpacing.Top = 5
       Caption = 'Meta Data Content:'
@@ -280,9 +280,9 @@ object frmSettings: TfrmSettings
       AnchorSideBottom.Control = gbPresentation
       AnchorSideBottom.Side = asrBottom
       Left = 156
-      Height = 179
-      Top = 235
-      Width = 762
+      Height = 140
+      Top = 238
+      Width = 764
       Anchors = [akTop, akLeft, akRight, akBottom]
       BorderSpacing.Left = 10
       BorderSpacing.Top = 5
@@ -296,9 +296,9 @@ object frmSettings: TfrmSettings
       AnchorSideTop.Control = btnTextColor
       AnchorSideTop.Side = asrBottom
       AnchorSideRight.Control = ImagePresentationPreview
-      Left = 372
+      Left = 373
       Height = 23
-      Top = 98
+      Top = 104
       Width = 344
       Anchors = [akTop]
       BorderSpacing.Left = 8
@@ -313,9 +313,9 @@ object frmSettings: TfrmSettings
       AnchorSideTop.Control = btnTextColor
       AnchorSideTop.Side = asrBottom
       AnchorSideRight.Control = btnBackgroundImage
-      Left = 159
-      Height = 26
-      Top = 98
+      Left = 160
+      Height = 25
+      Top = 104
       Width = 205
       Anchors = [akTop, akRight]
       BorderSpacing.Left = 10
@@ -330,10 +330,10 @@ object frmSettings: TfrmSettings
       AnchorSideTop.Control = btnBackgroundImage
       AnchorSideTop.Side = asrBottom
       AnchorSideRight.Control = ImagePresentationPreview
-      Left = 372
+      Left = 373
       Height = 21
       Hint = 'The transparency of the background picture towards the background color'
-      Top = 121
+      Top = 127
       Width = 344
       PageSize = 0
       ParentShowHint = False
@@ -348,9 +348,9 @@ object frmSettings: TfrmSettings
     object lblImageBrightness: TLabel
       AnchorSideTop.Control = sbImageBrightness
       AnchorSideRight.Control = sbImageBrightness
-      Left = 161
+      Left = 162
       Height = 21
-      Top = 121
+      Top = 127
       Width = 206
       Anchors = [akTop, akRight]
       BorderSpacing.Right = 5
@@ -363,9 +363,9 @@ object frmSettings: TfrmSettings
       AnchorSideTop.Control = sbImageBrightness
       AnchorSideTop.Side = asrBottom
       AnchorSideRight.Control = ImagePresentationPreview
-      Left = 588
+      Left = 589
       Height = 21
-      Top = 142
+      Top = 148
       Width = 128
       Anchors = [akTop, akRight]
       BorderSpacing.Right = 5
@@ -378,9 +378,9 @@ object frmSettings: TfrmSettings
       AnchorSideTop.Control = lblWrapAfter
       AnchorSideTop.Side = asrBottom
       AnchorSideRight.Control = cbShowBackgroundImage
-      Left = 99
-      Height = 29
-      Top = 50
+      Left = 100
+      Height = 34
+      Top = 56
       Width = 50
       Anchors = [akTop, akRight]
       BorderSpacing.Right = 5
@@ -394,8 +394,8 @@ object frmSettings: TfrmSettings
       AnchorSideRight.Control = btnFontSizeManually
       Left = 0
       Height = 21
-      Top = 29
-      Width = 364
+      Top = 35
+      Width = 365
       Anchors = [akTop, akLeft, akRight]
       Caption = 'Automatic wrap after how many lines (0 = off):'
       ParentColor = False
@@ -408,10 +408,10 @@ object frmSettings: TfrmSettings
       AnchorSideRight.Control = gbPresentation
       AnchorSideRight.Side = asrBottom
       AnchorSideBottom.Control = memoMetaData
-      Left = 721
-      Height = 201
-      Top = 29
-      Width = 195
+      Left = 722
+      Height = 198
+      Top = 35
+      Width = 196
       Anchors = [akTop, akLeft, akRight, akBottom]
       BorderSpacing.Left = 5
       BorderSpacing.Right = 2
@@ -425,8 +425,8 @@ object frmSettings: TfrmSettings
       AnchorSideTop.Control = sbImageBrightness
       AnchorSideTop.Side = asrBottom
       Left = 156
-      Height = 26
-      Top = 147
+      Height = 25
+      Top = 153
       Width = 158
       BorderSpacing.Left = 10
       BorderSpacing.Top = 5
@@ -442,8 +442,8 @@ object frmSettings: TfrmSettings
       AnchorSideRight.Control = comboHorizontal
       Left = 0
       Height = 21
-      Top = 4
-      Width = 367
+      Top = 7
+      Width = 368
       Alignment = taRightJustify
       Anchors = [akTop, akLeft, akRight]
       BorderSpacing.Right = 5
@@ -453,11 +453,11 @@ object frmSettings: TfrmSettings
     object comboHorizontal: TComboBox
       AnchorSideLeft.Control = btnFontSizeManually
       AnchorSideTop.Control = gbPresentation
-      Left = 372
-      Height = 29
+      Left = 373
+      Height = 35
       Top = 0
       Width = 190
-      ItemHeight = 21
+      ItemHeight = 27
       ItemIndex = 1
       Items.Strings = (
         'Left'
@@ -473,12 +473,12 @@ object frmSettings: TfrmSettings
       AnchorSideLeft.Control = comboHorizontal
       AnchorSideLeft.Side = asrBottom
       AnchorSideTop.Control = gbPresentation
-      Left = 567
-      Height = 29
+      Left = 568
+      Height = 35
       Top = 0
       Width = 190
       BorderSpacing.Left = 5
-      ItemHeight = 21
+      ItemHeight = 27
       ItemIndex = 1
       Items.Strings = (
         'Top'
@@ -496,8 +496,8 @@ object frmSettings: TfrmSettings
       AnchorSideTop.Control = comboVertical
       AnchorSideBottom.Control = comboVertical
       AnchorSideBottom.Side = asrBottom
-      Left = 762
-      Height = 29
+      Left = 763
+      Height = 35
       Top = 0
       Width = 74
       Anchors = [akTop, akLeft, akBottom]

--- a/src/forms/settings.lrj
+++ b/src/forms/settings.lrj
@@ -28,5 +28,6 @@
 {"hash":229805586,"name":"tfrmsettings.bgcolordialog.title","sourcebytes":[83,101,108,101,99,116,32,98,97,99,107,103,114,111,117,110,100,32,99,111,108,111,114],"value":"Select background color"},
 {"hash":207113506,"name":"tfrmsettings.textcolordialog.title","sourcebytes":[83,101,108,101,99,116,32,116,101,120,116,32,99,111,108,111,114],"value":"Select text color"},
 {"hash":24148789,"name":"tfrmsettings.bgpicturedialog.title","sourcebytes":[79,112,101,110,32,105,109,97,103,101,32,102,105,108,101],"value":"Open image file"},
-{"hash":24148789,"name":"tfrmsettings.bgpicturefiledialog.title","sourcebytes":[79,112,101,110,32,105,109,97,103,101,32,102,105,108,101],"value":"Open image file"}
+{"hash":24148789,"name":"tfrmsettings.bgpicturefiledialog.title","sourcebytes":[79,112,101,110,32,105,109,97,103,101,32,102,105,108,101],"value":"Open image file"},
+{"hash":101139877,"name":"tfrmsettings.cbhidecursorinpresentation.caption","sourcebytes":[72,105,100,101,32,109,111,117,115,101,32,99,117,114,115,111,114,32,105,110,32,112,114,101,115,101,110,116,97,116,105,111,110,32,109,111,100,101],"value":"Hide mouse cursor in presentation mode"}
 ]}

--- a/src/forms/settings.lrj
+++ b/src/forms/settings.lrj
@@ -3,7 +3,11 @@
 {"hash":96689322,"name":"tfrmsettings.labelsongdir.caption","sourcebytes":[83,111,110,103,32,82,101,112,111,32,80,97,116,104,58],"value":"Song Repo Path:"},
 {"hash":12558,"name":"tfrmsettings.btnselectdir.caption","sourcebytes":[46,46,46],"value":"..."},
 {"hash":249275155,"name":"tfrmsettings.cbemptyframe.caption","sourcebytes":[69,109,112,116,121,32,115,108,105,100,101,32,98,101,116,119,101,101,110,32,115,111,110,103,115],"value":"Empty slide between songs"},
+{"hash":192886297,"name":"tfrmsettings.cbblackscreenonempty.caption","sourcebytes":[83,104,111,119,32,98,108,97,99,107,32,115,99,114,101,101,110,32,119,104,101,110,32,115,108,105,100,101,32,105,115,32,101,109,112,116,121],"value":"Show black screen when slide is empty"},
 {"hash":166477907,"name":"tfrmsettings.cbspoiler.caption","sourcebytes":[83,112,111,105,108,32,110,101,120,116,32,115,108,105,100,101,115],"value":"Spoil next slides"},
+{"hash":251312435,"name":"tfrmsettings.cbfadetransition.caption","sourcebytes":[70,97,100,101,32,116,114,97,110,115,105,116,105,111,110,32,98,101,116,119,101,101,110,32,115,108,105,100,101,115],"value":"Fade transition between slides"},
+{"hash":1859,"name":"tfrmsettings.lblfadems.caption","sourcebytes":[109,115],"value":"ms"},
+{"hash":144602901,"name":"tfrmsettings.cbhidecursorinpresentation.caption","sourcebytes":[72,105,100,101,32,109,111,117,115,101,32,99,117,114,115,111,114,32,105,110,32,112,114,101,115,101,110,116,97,116,105,111,110,32,109,111,100,101],"value":"Hide mouse cursor in presentation mode"},
 {"hash":168348087,"name":"tfrmsettings.gbpresentation.caption","sourcebytes":[80,114,101,115,101,110,116,97,116,105,111,110,32,86,105,101,119],"value":"Presentation View"},
 {"hash":218647390,"name":"tfrmsettings.btnbackgroundcolor.caption","sourcebytes":[66,97,99,107,103,114,111,117,110,100,32,67,111,108,111,114,46,46,46],"value":"Background Color..."},
 {"hash":86685374,"name":"tfrmsettings.btnfontsizemanually.caption","sourcebytes":[67,104,97,110,103,101,32,70,111,110,116,32,83,101,116,116,105,110,103,115,46,46,46],"value":"Change Font Settings..."},
@@ -28,6 +32,5 @@
 {"hash":229805586,"name":"tfrmsettings.bgcolordialog.title","sourcebytes":[83,101,108,101,99,116,32,98,97,99,107,103,114,111,117,110,100,32,99,111,108,111,114],"value":"Select background color"},
 {"hash":207113506,"name":"tfrmsettings.textcolordialog.title","sourcebytes":[83,101,108,101,99,116,32,116,101,120,116,32,99,111,108,111,114],"value":"Select text color"},
 {"hash":24148789,"name":"tfrmsettings.bgpicturedialog.title","sourcebytes":[79,112,101,110,32,105,109,97,103,101,32,102,105,108,101],"value":"Open image file"},
-{"hash":24148789,"name":"tfrmsettings.bgpicturefiledialog.title","sourcebytes":[79,112,101,110,32,105,109,97,103,101,32,102,105,108,101],"value":"Open image file"},
-{"hash":101139877,"name":"tfrmsettings.cbhidecursorinpresentation.caption","sourcebytes":[72,105,100,101,32,109,111,117,115,101,32,99,117,114,115,111,114,32,105,110,32,112,114,101,115,101,110,116,97,116,105,111,110,32,109,111,100,101],"value":"Hide mouse cursor in presentation mode"}
+{"hash":24148789,"name":"tfrmsettings.bgpicturefiledialog.title","sourcebytes":[79,112,101,110,32,105,109,97,103,101,32,102,105,108,101],"value":"Open image file"}
 ]}

--- a/src/forms/settings.pas
+++ b/src/forms/settings.pas
@@ -25,6 +25,7 @@ type
     btnDetails: TButton;
     cbBlackScreenOnEmpty: TCheckBox;
     cbFadeTransition: TCheckBox;
+    cbHideCursorInPresentation: TCheckBox;
     lblFadeMs: TLabel;
     seFadeDuration: TSpinEdit;
     cbMetaDataFirstSlide: TCheckBox;
@@ -106,6 +107,7 @@ type
     function ExportPresentationStyleSettings: TPresentationStyleSettings;
     function GetRepositoryPath: String;
     function GetSettingsFile: TINIFile;
+    function GetHideCursorInPresentation: Boolean;
     procedure SetPortalsUsedFlag;
   end;
 
@@ -393,6 +395,7 @@ begin
   cbFadeTransition.Checked := settingsFile.ReadBool('Config', 'FadeTransition', True);
   seFadeDuration.Value := settingsFile.ReadInteger('Config', 'FadeDurationMs', 150);
   seFadeDuration.Enabled := cbFadeTransition.Checked;
+  cbHideCursorInPresentation.Checked := settingsFile.ReadBool('Config', 'HideCursorInPresentation', False);
   textColorDialog.Color := StringToColor(settingsFile.ReadString('Config',
     'Text-Color', 'clWhite'));
   bgColorDialog.Color := StringToColor(settingsFile.ReadString('Config',
@@ -514,6 +517,7 @@ begin
       settingsFile.WriteBool('Config', 'BlackScreenOnEmpty', cbBlackScreenOnEmpty.Checked);
       settingsFile.WriteBool('Config', 'FadeTransition', cbFadeTransition.Checked);
       settingsFile.WriteInteger('Config', 'FadeDurationMs', seFadeDuration.Value);
+      settingsFile.WriteBool('Config', 'HideCursorInPresentation', cbHideCursorInPresentation.Checked);
       settingsFile.WriteString('Config', 'Text-Color',
         ColorToString(textColorDialog.Color));
       settingsFile.WriteString('Config', 'Background-Color',
@@ -635,6 +639,11 @@ end;
 function TfrmSettings.GetSettingsFile: TINIFile;
 begin
   Result := SettingsFile;
+end;
+
+function TfrmSettings.GetHideCursorInPresentation: Boolean;
+begin
+  Result := cbHideCursorInPresentation.Checked;
 end;
 
 procedure TfrmSettings.SetPortalsUsedFlag;

--- a/src/forms/settingspadding.lfm
+++ b/src/forms/settingspadding.lfm
@@ -6,7 +6,7 @@ object FormPadding: TFormPadding
   Caption = 'Additional Settings'
   ClientHeight = 240
   ClientWidth = 320
-  LCLVersion = '3.2.0.0'
+  LCLVersion = '4.6.0.0'
   inline frmSettingsDetailed: TFrameSettingsDetailed
     Height = 240
     Width = 320

--- a/src/forms/songselection.lfm
+++ b/src/forms/songselection.lfm
@@ -9,7 +9,7 @@ object frmSongs: TfrmSongs
   ClientWidth = 1290
   Menu = MainMenu
   Position = poScreenCenter
-  LCLVersion = '4.4.0.0'
+  LCLVersion = '4.6.0.0'
   OnActivate = FormActivate
   OnChangeBounds = FormResize
   OnClose = FormClose

--- a/src/forms/songselection.lrj
+++ b/src/forms/songselection.lrj
@@ -5,6 +5,7 @@
 {"hash":60144,"name":"tfrmsongs.btngoleft.caption","sourcebytes":[226,134,144],"value":"\u2190"},
 {"hash":60146,"name":"tfrmsongs.btngoright.caption","sourcebytes":[226,134,146],"value":"\u2192"},
 {"hash":3271,"name":"tfrmsongs.btnquitpresentation.caption","sourcebytes":[195,151],"value":"\u00D7"},
+{"hash":60416,"name":"tfrmsongs.btntoggleblack.caption","sourcebytes":[226,150,160],"value":"\u25A0"},
 {"hash":262941619,"name":"tfrmsongs.lblfoilnumber.caption","sourcebytes":[83,108,105,100,101,32,78,117,109,98,101,114,115],"value":"Slide Numbers"},
 {"hash":43,"name":"tfrmsongs.btnadd.caption","sourcebytes":[43],"value":"+"},
 {"hash":45,"name":"tfrmsongs.btnremove.caption","sourcebytes":[45],"value":"-"},
@@ -38,5 +39,6 @@
 {"hash":233785182,"name":"tfrmsongs.itemshowwelcomeassistent.caption","sourcebytes":[83,104,111,119,32,87,101,108,99,111,109,101,32,65,115,115,105,115,116,101,110,116,46,46,46],"value":"Show Welcome Assistent..."},
 {"hash":39161316,"name":"tfrmsongs.opendialog.title","sourcebytes":[79,112,101,110,32,83,111,110,103,32,76,105,115,116],"value":"Open Song List"},
 {"hash":206867828,"name":"tfrmsongs.savedialog.title","sourcebytes":[83,97,118,101,32,83,111,110,103,32,76,105,115,116],"value":"Save Song List"},
-{"hash":102791358,"name":"tfrmsongs.itemopenineditor.caption","sourcebytes":[79,112,101,110,32,105,110,32,69,100,105,116,111,114,46,46,46],"value":"Open in Editor..."}
+{"hash":102791358,"name":"tfrmsongs.itemopenineditor.caption","sourcebytes":[79,112,101,110,32,105,110,32,69,100,105,116,111,114,46,46,46],"value":"Open in Editor..."},
+{"hash":85848798,"name":"tfrmsongs.itemeditsongstyle.caption","sourcebytes":[69,100,105,116,32,115,111,110,103,32,115,116,121,108,101,46,46,46],"value":"Edit song style..."}
 ]}

--- a/src/forms/welcome.lfm
+++ b/src/forms/welcome.lfm
@@ -7,10 +7,10 @@ object frmWelcome: TfrmWelcome
   Caption = 'Cantara Setup'
   ClientHeight = 489
   ClientWidth = 689
+  Position = poOwnerFormCenter
+  LCLVersion = '4.6.0.0'
   OnCloseQuery = FormCloseQuery
   OnShow = FormShow
-  Position = poOwnerFormCenter
-  LCLVersion = '3.2.0.0'
   object Notebook: TNotebook
     AnchorSideLeft.Control = Owner
     AnchorSideTop.Control = Owner

--- a/src/frames/editordisplaysongcontent.lfm
+++ b/src/frames/editordisplaysongcontent.lfm
@@ -5,12 +5,13 @@ object frmDisplaySongContent: TfrmDisplaySongContent
   Width = 892
   ClientHeight = 452
   ClientWidth = 892
+  LCLVersion = '4.6.0.0'
   TabOrder = 0
   DesignLeft = 626
   DesignTop = 266
   object lblSongName: TLabel
     Left = 0
-    Height = 22
+    Height = 21
     Top = 0
     Width = 51
     Caption = 'Name: '

--- a/src/frames/fulltextsearch.lfm
+++ b/src/frames/fulltextsearch.lfm
@@ -6,6 +6,7 @@ object FrmFulltextsearch: TFrmFulltextsearch
   ClientHeight = 255
   ClientWidth = 424
   Color = clWindow
+  LCLVersion = '4.6.0.0'
   ParentBackground = False
   ParentColor = False
   TabOrder = 0

--- a/src/frames/settingsdetailed.lfm
+++ b/src/frames/settingsdetailed.lfm
@@ -5,6 +5,7 @@ object FrameSettingsDetailed: TFrameSettingsDetailed
   Width = 381
   ClientHeight = 325
   ClientWidth = 381
+  LCLVersion = '4.6.0.0'
   TabOrder = 0
   DesignLeft = 423
   DesignTop = 34

--- a/src/locals/cantara.ar.po
+++ b/src/locals/cantara.ar.po
@@ -576,6 +576,10 @@ msgstr "شريحة فارغة بين الأغاني"
 msgid "Fade transition between slides"
 msgstr "انتقال تلاشي بين الشرائح"
 
+#: tfrmsettings.cbhidecursorinpresentation.caption
+msgid "Hide mouse cursor in presentation mode"
+msgstr ""
+
 #: tfrmsettings.cbmetadatafirstslide.caption
 msgid "at first slide"
 msgstr "في الشريحة الأولى"

--- a/src/locals/cantara.ar.po
+++ b/src/locals/cantara.ar.po
@@ -208,7 +208,9 @@ msgid "Hint"
 msgstr "تلميح"
 
 #: songselection.strpptxgenjs
-msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs[](https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
+#, fuzzy
+#| msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs[](https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
+msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs (https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
 msgstr "يستخدم Cantara محرك JavaScript في متصفح الويب الافتراضي المحلي الخاص بك ومكتبة JavaScript مفتوحة المصدر PptxGenJs[](https://gitbrent.github.io/PptxGenJS/) لإنشاء ملف pptx. لذلك، بعد الضغط على موافق، سيفتح متصفح الويب الخاص بك ويطلب منك مكانًا لحفظ ملف pptx بعد اكتمال الإنشاء بنجاح. خلال هذه العملية، لا حاجة لاتصال بالإنترنت ولا تتم مشاركة أي بيانات مع أي شخص آخر عبر متصفحك. إذا أردت المتابعة، اضغط على موافق ولن تظهر هذه الرسالة مرة أخرى في المرات القادمة. إذا لم ترغب في المتابعة، اضغط على إلغاء."
 
 #: songselection.strsongisempty
@@ -768,6 +770,10 @@ msgctxt "tfrmsongs.btnstartpresentation.caption"
 msgid "Presentation..."
 msgstr "العرض…"
 
+#: tfrmsongs.btntoggleblack.caption
+msgid "■"
+msgstr ""
+
 #: tfrmsongs.btnup.caption
 msgid "🠕"
 msgstr "🠕"
@@ -1069,3 +1075,4 @@ msgstr "يمكن استخدام المجلد المحدد بنجاح كمستو�
 #: welcome.strnosongrepoyet
 msgid "Please select a song repository path before you leave the assistent. Cantara can not work without it."
 msgstr "يرجى اختيار مسار مستودع الأغاني قبل مغادرة المساعد. لا يمكن لـ Cantara العمل بدونه."
+

--- a/src/locals/cantara.ar.po
+++ b/src/locals/cantara.ar.po
@@ -580,7 +580,7 @@ msgstr "انتقال تلاشي بين الشرائح"
 
 #: tfrmsettings.cbhidecursorinpresentation.caption
 msgid "Hide mouse cursor in presentation mode"
-msgstr ""
+msgstr "إخفاء مؤشر الماوس في وضع العرض"
 
 #: tfrmsettings.cbmetadatafirstslide.caption
 msgid "at first slide"

--- a/src/locals/cantara.ar.po
+++ b/src/locals/cantara.ar.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cantara\n"
 "POT-Creation-Date: \n"
-"PO-Revision-Date: 2026-02-21\n"
-"Last-Translator: \n"
+"PO-Revision-Date: 2026-07-08 18:32\n"
+"Last-Translator: Jan Martin Reckel <jm.reckel@t-online.de>\n"
 "Language-Team: Arabic\n"
 "Language: ar\n"
 "MIME-Version: 1.0\n"
@@ -208,8 +208,6 @@ msgid "Hint"
 msgstr "تلميح"
 
 #: songselection.strpptxgenjs
-#, fuzzy
-#| msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs[](https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
 msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs (https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
 msgstr "يستخدم Cantara محرك JavaScript في متصفح الويب الافتراضي المحلي الخاص بك ومكتبة JavaScript مفتوحة المصدر PptxGenJs[](https://gitbrent.github.io/PptxGenJS/) لإنشاء ملف pptx. لذلك، بعد الضغط على موافق، سيفتح متصفح الويب الخاص بك ويطلب منك مكانًا لحفظ ملف pptx بعد اكتمال الإنشاء بنجاح. خلال هذه العملية، لا حاجة لاتصال بالإنترنت ولا تتم مشاركة أي بيانات مع أي شخص آخر عبر متصفحك. إذا أردت المتابعة، اضغط على موافق ولن تظهر هذه الرسالة مرة أخرى في المرات القادمة. إذا لم ترغب في المتابعة، اضغط على إلغاء."
 
@@ -526,7 +524,6 @@ msgid "Open image file"
 msgstr "فتح ملف الصورة"
 
 #: tfrmsettings.bgpicturefiledialog.title
-#, fuzzy
 msgctxt "tfrmsettings.bgpicturefiledialog.title"
 msgid "Open image file"
 msgstr "فتح ملف الصورة"
@@ -783,8 +780,6 @@ msgid "Close File"
 msgstr "إغلاق الملف"
 
 #: tfrmsongs.caption
-#, fuzzy
-#| msgid "Song Selection (Cantara)"
 msgctxt "tfrmsongs.caption"
 msgid "Cantara"
 msgstr "Cantara"

--- a/src/locals/cantara.de.po
+++ b/src/locals/cantara.de.po
@@ -578,6 +578,10 @@ msgstr "Leerfolie zwischen den Liedern einfügen"
 msgid "Fade transition between slides"
 msgstr "Übergangszeit zwischen den Folien"
 
+#: tfrmsettings.cbhidecursorinpresentation.caption
+msgid "Hide mouse cursor in presentation mode"
+msgstr "Mauszeiger im Präsentationsmodus verstecken"
+
 #: tfrmsettings.cbmetadatafirstslide.caption
 msgid "at first slide"
 msgstr "bei der ersten Folie"

--- a/src/locals/cantara.de.po
+++ b/src/locals/cantara.de.po
@@ -1056,7 +1056,7 @@ msgstr "Weiter"
 
 #: welcome.songrepodirempty
 msgid "However it seems that you have not added any songs yet. Would you like to add the song \"Amazing Grace\" from John Newton as an example to your song repository? Then click at the button below. Click \"Next\" to go to the next step."
-msgstr "Es scheint jedoch, dass Sie noch keine Lieder hinzugefügt haben. Möchten Sie das Lied „Amazing Grace“ von John Newton als Beispiel zu Ihrem Liederverzeichnis hinzufügen? Dann klicken Sie auf"
+msgstr "Es scheint jedoch, dass Sie noch keine Lieder hinzugefügt haben. Möchten Sie das Lied „Amazing Grace“ von John Newton als Beispiel zu Ihrem Liederverzeichnis hinzufügen? Dann klicken Sie auf die Schaltfläche unten. Klicken Sie auf „Weiter“, um mit dem nächsten Schritt fortzufahren."
 
 #: welcome.songreponotempty
 msgid "The song repository contains already {songcount} songs which you can use with Cantara."

--- a/src/locals/cantara.de.po
+++ b/src/locals/cantara.de.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "POT-Creation-Date: \n"
-"PO-Revision-Date: \n"
+"PO-Revision-Date: 2026-07-08 18:32\n"
 "Last-Translator: Jan Martin Reckel <jm.reckel@t-online.de>\n"
 "Language-Team: \n"
 "Language: de\n"
@@ -526,7 +526,6 @@ msgid "Open image file"
 msgstr "Bilddatei laden"
 
 #: tfrmsettings.bgpicturefiledialog.title
-#, fuzzy
 msgctxt "tfrmsettings.bgpicturefiledialog.title"
 msgid "Open image file"
 msgstr "Bilddatei laden"
@@ -784,8 +783,6 @@ msgid "Close File"
 msgstr "Datei schließen"
 
 #: tfrmsongs.caption
-#, fuzzy
-#| msgid "Song Selection (Cantara)"
 msgctxt "tfrmsongs.caption"
 msgid "Cantara"
 msgstr "Liedauswahl (Cantara)"
@@ -1058,8 +1055,6 @@ msgid "Next"
 msgstr "Weiter"
 
 #: welcome.songrepodirempty
-#, fuzzy
-#| msgid "However it seems that you have not added any songs yet. Would you like to add the song \"Amazing Grace\" from John Newton as an example to your song repository? Then click at"
 msgid "However it seems that you have not added any songs yet. Would you like to add the song \"Amazing Grace\" from John Newton as an example to your song repository? Then click at the button below. Click \"Next\" to go to the next step."
 msgstr "Es scheint jedoch, dass Sie noch keine Lieder hinzugefügt haben. Möchten Sie das Lied „Amazing Grace“ von John Newton als Beispiel zu Ihrem Liederverzeichnis hinzufügen? Dann klicken Sie auf"
 

--- a/src/locals/cantara.de.po
+++ b/src/locals/cantara.de.po
@@ -771,6 +771,10 @@ msgctxt "tfrmsongs.btnstartpresentation.caption"
 msgid "Presentation..."
 msgstr "Präsentation..."
 
+#: tfrmsongs.btntoggleblack.caption
+msgid "■"
+msgstr ""
+
 #: tfrmsongs.btnup.caption
 msgid "🠕"
 msgstr "🠕"

--- a/src/locals/cantara.es.po
+++ b/src/locals/cantara.es.po
@@ -24,6 +24,10 @@ msgstr "Introduzca el nuevo nombre de la canción: "
 msgid "The file can not be converted. Make sure that you have the permissions to write to the song repository!"
 msgstr "El archivo no se puede convertir. ¡Asegúrese de que tiene permisos para escribir en el repositorio de canciones!"
 
+#: editordisplaysongcontent.strfilecannotberenamed
+msgid "The File can not be renamed. Make sure that you have the permissions to write to the song repository!"
+msgstr "El archivo no puede ser renombrado. ¡Asegúrese de que tiene permisos para escribir en el repositorio de canciones!"
+
 #: flatpakhandling.messagecantaraneedsportaluse
 msgid ""
 "You are using Cantara as a Flatpak. Due to an update of the permissions, Cantara can't access your home directory anymore which helps to make your system securer. However, that also means that you have to select the song repository path once again, so that Cantara will be granted access to that directory. You also need to select the background image once again if you had one in use.\n"
@@ -204,7 +208,9 @@ msgid "Hint"
 msgstr "Aviso"
 
 #: songselection.strpptxgenjs
-msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs[](https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
+#, fuzzy
+#| msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs[](https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
+msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs (https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
 msgstr "Cantara está utilizando el motor JavaScript de su navegador web predeterminado y la biblioteca JavaScript de código abierto PptxGenJS[](https://gitbrent.github.io/PptxGenJS/) para generar el archivo pptx. Por lo tanto, después de presionar Aceptar, su navegador web se abrirá y le pedirá un lugar para guardar el archivo pptx cuando la generación se haya completado con éxito. Durante este proceso, no se necesita conexión a Internet y no se comparten datos con nadie más aparte de su navegador. Si desea continuar, presione Aceptar y este mensaje no volverá a aparecer la próxima vez. Si no desea continuar, presione Cancelar."
 
 #: songselection.strsongisempty
@@ -764,6 +770,10 @@ msgctxt "tfrmsongs.btnstartpresentation.caption"
 msgid "Presentation..."
 msgstr "Presentación..."
 
+#: tfrmsongs.btntoggleblack.caption
+msgid "■"
+msgstr ""
+
 #: tfrmsongs.btnup.caption
 msgid "🠕"
 msgstr "🠕"
@@ -1066,6 +1076,3 @@ msgstr "El directorio seleccionado puede usarse correctamente como repositorio d
 msgid "Please select a song repository path before you leave the assistent. Cantara can not work without it."
 msgstr "Por favor, seleccione una ruta de repositorio de canciones antes de salir del asistente. Cantara no puede funcionar sin ella."
 
-#: editordisplaysongcontent.strfilecannotberenamed
-msgid "The File can not be renamed. Make sure that you have the permissions to write to the song repository!"
-msgstr "El archivo no puede ser renombrado. ¡Asegúrese de que tiene permisos para escribir en el repositorio de canciones!"

--- a/src/locals/cantara.es.po
+++ b/src/locals/cantara.es.po
@@ -580,7 +580,7 @@ msgstr "Transición de fundido entre diapositivas"
 
 #: tfrmsettings.cbhidecursorinpresentation.caption
 msgid "Hide mouse cursor in presentation mode"
-msgstr ""
+msgstr "Ocultar el cursor del ratón en el modo de presentación"
 
 #: tfrmsettings.cbmetadatafirstslide.caption
 msgid "at first slide"

--- a/src/locals/cantara.es.po
+++ b/src/locals/cantara.es.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "POT-Creation-Date: \n"
-"PO-Revision-Date: \n"
-"Last-Translator: \n"
+"PO-Revision-Date: 2026-07-08 18:32\n"
+"Last-Translator: Jan Martin Reckel <jm.reckel@t-online.de>\n"
 "Language-Team: \n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
@@ -208,8 +208,6 @@ msgid "Hint"
 msgstr "Aviso"
 
 #: songselection.strpptxgenjs
-#, fuzzy
-#| msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs[](https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
 msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs (https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
 msgstr "Cantara está utilizando el motor JavaScript de su navegador web predeterminado y la biblioteca JavaScript de código abierto PptxGenJS[](https://gitbrent.github.io/PptxGenJS/) para generar el archivo pptx. Por lo tanto, después de presionar Aceptar, su navegador web se abrirá y le pedirá un lugar para guardar el archivo pptx cuando la generación se haya completado con éxito. Durante este proceso, no se necesita conexión a Internet y no se comparten datos con nadie más aparte de su navegador. Si desea continuar, presione Aceptar y este mensaje no volverá a aparecer la próxima vez. Si no desea continuar, presione Cancelar."
 
@@ -526,7 +524,6 @@ msgid "Open image file"
 msgstr "Abrir archivo de imagen"
 
 #: tfrmsettings.bgpicturefiledialog.title
-#, fuzzy
 msgctxt "tfrmsettings.bgpicturefiledialog.title"
 msgid "Open image file"
 msgstr "Abrir archivo de imagen"
@@ -783,8 +780,6 @@ msgid "Close File"
 msgstr "Cerrar archivo"
 
 #: tfrmsongs.caption
-#, fuzzy
-#| msgid "Song Selection (Cantara)"
 msgctxt "tfrmsongs.caption"
 msgid "Cantara"
 msgstr "Cantara"

--- a/src/locals/cantara.es.po
+++ b/src/locals/cantara.es.po
@@ -572,6 +572,10 @@ msgstr "Diapositiva vacía entre canciones"
 msgid "Fade transition between slides"
 msgstr "Transición de fundido entre diapositivas"
 
+#: tfrmsettings.cbhidecursorinpresentation.caption
+msgid "Hide mouse cursor in presentation mode"
+msgstr ""
+
 #: tfrmsettings.cbmetadatafirstslide.caption
 msgid "at first slide"
 msgstr "en la primera diapositiva"

--- a/src/locals/cantara.fa.po
+++ b/src/locals/cantara.fa.po
@@ -580,7 +580,7 @@ msgstr "انتقال محو بین اسلایدها"
 
 #: tfrmsettings.cbhidecursorinpresentation.caption
 msgid "Hide mouse cursor in presentation mode"
-msgstr ""
+msgstr "مخفی کردن نشانگر ماوس در حالت ارائه"
 
 #: tfrmsettings.cbmetadatafirstslide.caption
 msgid "at first slide"

--- a/src/locals/cantara.fa.po
+++ b/src/locals/cantara.fa.po
@@ -576,6 +576,10 @@ msgstr "اسلاید خالی بین آهنگ‌ها"
 msgid "Fade transition between slides"
 msgstr "انتقال محو بین اسلایدها"
 
+#: tfrmsettings.cbhidecursorinpresentation.caption
+msgid "Hide mouse cursor in presentation mode"
+msgstr ""
+
 #: tfrmsettings.cbmetadatafirstslide.caption
 msgid "at first slide"
 msgstr "در اسلاید اول"

--- a/src/locals/cantara.fa.po
+++ b/src/locals/cantara.fa.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cantara\n"
 "POT-Creation-Date: \n"
-"PO-Revision-Date: 2026-02-21\n"
-"Last-Translator: \n"
+"PO-Revision-Date: 2026-07-08 18:32\n"
+"Last-Translator: Jan Martin Reckel <jm.reckel@t-online.de>\n"
 "Language-Team: Persian (Farsi)\n"
 "Language: fa\n"
 "MIME-Version: 1.0\n"
@@ -208,8 +208,6 @@ msgid "Hint"
 msgstr "نکته"
 
 #: songselection.strpptxgenjs
-#, fuzzy
-#| msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs[](https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
 msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs (https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
 msgstr "Cantara از موتور جاوااسکریپت مرورگر پیش‌فرض محلی شما و کتابخانه متن‌باز جاوااسکریپت PptxGenJs[](https://gitbrent.github.io/PptxGenJS/) برای تولید فایل pptx استفاده می‌کند. بنابراین پس از زدن OK، مرورگر وب شما باز می‌شود و پس از اتمام موفقیت‌آمیز تولید، از شما مکان ذخیره فایل pptx را می‌پرسد. در طول این فرآیند نیازی به اتصال اینترنت نیست و هیچ داده‌ای با شخص دیگری به اشتراک گذاشته نمی‌شود (به جز مرورگر شما). اگر می‌خواهید ادامه دهید، OK را بزنید و این پیام در دفعات بعدی نمایش داده نمی‌شود. اگر نمی‌خواهید ادامه دهید، لطفاً Cancel را بزنید."
 
@@ -526,7 +524,6 @@ msgid "Open image file"
 msgstr "باز کردن فایل تصویر"
 
 #: tfrmsettings.bgpicturefiledialog.title
-#, fuzzy
 msgctxt "tfrmsettings.bgpicturefiledialog.title"
 msgid "Open image file"
 msgstr "باز کردن فایل تصویر"
@@ -783,8 +780,6 @@ msgid "Close File"
 msgstr "بستن فایل"
 
 #: tfrmsongs.caption
-#, fuzzy
-#| msgid "Song Selection (Cantara)"
 msgctxt "tfrmsongs.caption"
 msgid "Cantara"
 msgstr "Cantara"

--- a/src/locals/cantara.fa.po
+++ b/src/locals/cantara.fa.po
@@ -208,7 +208,9 @@ msgid "Hint"
 msgstr "نکته"
 
 #: songselection.strpptxgenjs
-msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs[](https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
+#, fuzzy
+#| msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs[](https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
+msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs (https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
 msgstr "Cantara از موتور جاوااسکریپت مرورگر پیش‌فرض محلی شما و کتابخانه متن‌باز جاوااسکریپت PptxGenJs[](https://gitbrent.github.io/PptxGenJS/) برای تولید فایل pptx استفاده می‌کند. بنابراین پس از زدن OK، مرورگر وب شما باز می‌شود و پس از اتمام موفقیت‌آمیز تولید، از شما مکان ذخیره فایل pptx را می‌پرسد. در طول این فرآیند نیازی به اتصال اینترنت نیست و هیچ داده‌ای با شخص دیگری به اشتراک گذاشته نمی‌شود (به جز مرورگر شما). اگر می‌خواهید ادامه دهید، OK را بزنید و این پیام در دفعات بعدی نمایش داده نمی‌شود. اگر نمی‌خواهید ادامه دهید، لطفاً Cancel را بزنید."
 
 #: songselection.strsongisempty
@@ -768,6 +770,10 @@ msgctxt "tfrmsongs.btnstartpresentation.caption"
 msgid "Presentation..."
 msgstr "ارائه…"
 
+#: tfrmsongs.btntoggleblack.caption
+msgid "■"
+msgstr ""
+
 #: tfrmsongs.btnup.caption
 msgid "🠕"
 msgstr "🠕"
@@ -1069,3 +1075,4 @@ msgstr "پوشه انتخاب‌شده با موفقیت می‌تواند به 
 #: welcome.strnosongrepoyet
 msgid "Please select a song repository path before you leave the assistent. Cantara can not work without it."
 msgstr "لطفاً پیش از ترک راهنما، مسیر مخزن آهنگ‌ها را انتخاب کنید. Cantara بدون آن کار نمی‌کند."
+

--- a/src/locals/cantara.fr.po
+++ b/src/locals/cantara.fr.po
@@ -208,7 +208,9 @@ msgid "Hint"
 msgstr "Astuce"
 
 #: songselection.strpptxgenjs
-msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs[](https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
+#, fuzzy
+#| msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs[](https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
+msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs (https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
 msgstr "Cantara utilise le moteur JavaScript de votre navigateur web par défaut et la bibliothèque open source PptxGenJS[](https://gitbrent.github.io/PptxGenJS/) pour générer le fichier pptx. Après avoir cliqué sur OK, votre navigateur s’ouvrira et vous demandera où sauvegarder le fichier pptx une fois la génération terminée avec succès. Ce processus ne nécessite aucune connexion Internet et aucune donnée n’est partagée avec quiconque en dehors de votre navigateur. Si vous souhaitez continuer, cliquez sur OK (ce message n’apparaîtra plus par la suite). Si vous ne souhaitez pas continuer, cliquez sur Annuler."
 
 #: songselection.strsongisempty
@@ -768,6 +770,10 @@ msgctxt "tfrmsongs.btnstartpresentation.caption"
 msgid "Presentation..."
 msgstr "Présentation…"
 
+#: tfrmsongs.btntoggleblack.caption
+msgid "■"
+msgstr ""
+
 #: tfrmsongs.btnup.caption
 msgid "🠕"
 msgstr "🠕"
@@ -1069,3 +1075,4 @@ msgstr "Le dossier sélectionné peut être utilisé avec succès comme réperto
 #: welcome.strnosongrepoyet
 msgid "Please select a song repository path before you leave the assistent. Cantara can not work without it."
 msgstr "Veuillez sélectionner un chemin de répertoire de chansons avant de quitter l’assistant. Cantara ne peut pas fonctionner sans cela."
+

--- a/src/locals/cantara.fr.po
+++ b/src/locals/cantara.fr.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cantara\n"
 "POT-Creation-Date: \n"
-"PO-Revision-Date: 2026-02-21\n"
-"Last-Translator: \n"
+"PO-Revision-Date: 2026-07-08 18:32\n"
+"Last-Translator: Jan Martin Reckel <jm.reckel@t-online.de>\n"
 "Language-Team: French\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
@@ -208,8 +208,6 @@ msgid "Hint"
 msgstr "Astuce"
 
 #: songselection.strpptxgenjs
-#, fuzzy
-#| msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs[](https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
 msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs (https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
 msgstr "Cantara utilise le moteur JavaScript de votre navigateur web par défaut et la bibliothèque open source PptxGenJS[](https://gitbrent.github.io/PptxGenJS/) pour générer le fichier pptx. Après avoir cliqué sur OK, votre navigateur s’ouvrira et vous demandera où sauvegarder le fichier pptx une fois la génération terminée avec succès. Ce processus ne nécessite aucune connexion Internet et aucune donnée n’est partagée avec quiconque en dehors de votre navigateur. Si vous souhaitez continuer, cliquez sur OK (ce message n’apparaîtra plus par la suite). Si vous ne souhaitez pas continuer, cliquez sur Annuler."
 
@@ -526,7 +524,6 @@ msgid "Open image file"
 msgstr "Ouvrir un fichier image"
 
 #: tfrmsettings.bgpicturefiledialog.title
-#, fuzzy
 msgctxt "tfrmsettings.bgpicturefiledialog.title"
 msgid "Open image file"
 msgstr "Ouvrir un fichier image"
@@ -783,8 +780,6 @@ msgid "Close File"
 msgstr "Fermer le fichier"
 
 #: tfrmsongs.caption
-#, fuzzy
-#| msgid "Song Selection (Cantara)"
 msgctxt "tfrmsongs.caption"
 msgid "Cantara"
 msgstr "Cantara"

--- a/src/locals/cantara.fr.po
+++ b/src/locals/cantara.fr.po
@@ -580,7 +580,7 @@ msgstr "Transition en fondu entre les diapositives"
 
 #: tfrmsettings.cbhidecursorinpresentation.caption
 msgid "Hide mouse cursor in presentation mode"
-msgstr ""
+msgstr "Masquer le curseur de la souris en mode présentation"
 
 #: tfrmsettings.cbmetadatafirstslide.caption
 msgid "at first slide"

--- a/src/locals/cantara.fr.po
+++ b/src/locals/cantara.fr.po
@@ -576,6 +576,10 @@ msgstr "Diapositive vide entre les chansons"
 msgid "Fade transition between slides"
 msgstr "Transition en fondu entre les diapositives"
 
+#: tfrmsettings.cbhidecursorinpresentation.caption
+msgid "Hide mouse cursor in presentation mode"
+msgstr ""
+
 #: tfrmsettings.cbmetadatafirstslide.caption
 msgid "at first slide"
 msgstr "sur la première diapositive"

--- a/src/locals/cantara.he.po
+++ b/src/locals/cantara.he.po
@@ -580,7 +580,7 @@ msgstr "מעבר התפוגגות בין שקופיות"
 
 #: tfrmsettings.cbhidecursorinpresentation.caption
 msgid "Hide mouse cursor in presentation mode"
-msgstr ""
+msgstr "הסתר את סמן העכבר במצב מצגת"
 
 #: tfrmsettings.cbmetadatafirstslide.caption
 msgid "at first slide"

--- a/src/locals/cantara.he.po
+++ b/src/locals/cantara.he.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cantara\n"
 "POT-Creation-Date: \n"
-"PO-Revision-Date: 2026-02-21\n"
-"Last-Translator: \n"
+"PO-Revision-Date: 2026-07-08 18:32\n"
+"Last-Translator: Jan Martin Reckel <jm.reckel@t-online.de>\n"
 "Language-Team: Hebrew\n"
 "Language: he\n"
 "MIME-Version: 1.0\n"
@@ -208,8 +208,6 @@ msgid "Hint"
 msgstr "רמז"
 
 #: songselection.strpptxgenjs
-#, fuzzy
-#| msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs[](https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
 msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs (https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
 msgstr "Cantara משתמש במנוע JavaScript של הדפדפן המוגדר כברירת מחדל במחשב שלך ובספריית JavaScript בקוד פתוח PptxGenJs[](https://gitbrent.github.io/PptxGenJS/) כדי ליצור קובץ pptx. לכן, לאחר לחיצה על אישור, הדפדפן שלך ייפתח ויבקש ממך מקום לשמירת הקובץ לאחר שהיצירה הסתיימה בהצלחה. במהלך התהליך הזה אין צורך בחיבור אינטרנט ואין שיתוף נתונים עם אף אחד מלבד הדפדפן שלך. אם ברצונך להמשיך – לחץ/י אישור (ההודעה לא תופיע שוב בפעמים הבאות). אם אינך רוצה להמשיך – לחץ/י ביטול."
 
@@ -526,7 +524,6 @@ msgid "Open image file"
 msgstr "פתח קובץ תמונה"
 
 #: tfrmsettings.bgpicturefiledialog.title
-#, fuzzy
 msgctxt "tfrmsettings.bgpicturefiledialog.title"
 msgid "Open image file"
 msgstr "פתח קובץ תמונה"
@@ -783,8 +780,6 @@ msgid "Close File"
 msgstr "סגור קובץ"
 
 #: tfrmsongs.caption
-#, fuzzy
-#| msgid "Song Selection (Cantara)"
 msgctxt "tfrmsongs.caption"
 msgid "Cantara"
 msgstr "Cantara"

--- a/src/locals/cantara.he.po
+++ b/src/locals/cantara.he.po
@@ -576,6 +576,10 @@ msgstr "שקופית ריקה בין שירים"
 msgid "Fade transition between slides"
 msgstr "מעבר התפוגגות בין שקופיות"
 
+#: tfrmsettings.cbhidecursorinpresentation.caption
+msgid "Hide mouse cursor in presentation mode"
+msgstr ""
+
 #: tfrmsettings.cbmetadatafirstslide.caption
 msgid "at first slide"
 msgstr "בשקופית הראשונה"

--- a/src/locals/cantara.he.po
+++ b/src/locals/cantara.he.po
@@ -208,7 +208,9 @@ msgid "Hint"
 msgstr "רמז"
 
 #: songselection.strpptxgenjs
-msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs[](https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
+#, fuzzy
+#| msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs[](https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
+msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs (https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
 msgstr "Cantara משתמש במנוע JavaScript של הדפדפן המוגדר כברירת מחדל במחשב שלך ובספריית JavaScript בקוד פתוח PptxGenJs[](https://gitbrent.github.io/PptxGenJS/) כדי ליצור קובץ pptx. לכן, לאחר לחיצה על אישור, הדפדפן שלך ייפתח ויבקש ממך מקום לשמירת הקובץ לאחר שהיצירה הסתיימה בהצלחה. במהלך התהליך הזה אין צורך בחיבור אינטרנט ואין שיתוף נתונים עם אף אחד מלבד הדפדפן שלך. אם ברצונך להמשיך – לחץ/י אישור (ההודעה לא תופיע שוב בפעמים הבאות). אם אינך רוצה להמשיך – לחץ/י ביטול."
 
 #: songselection.strsongisempty
@@ -768,6 +770,10 @@ msgctxt "tfrmsongs.btnstartpresentation.caption"
 msgid "Presentation..."
 msgstr "מצגת…"
 
+#: tfrmsongs.btntoggleblack.caption
+msgid "■"
+msgstr ""
+
 #: tfrmsongs.btnup.caption
 msgid "🠕"
 msgstr "🠕"
@@ -1069,3 +1075,4 @@ msgstr "התיקייה שנבחרה יכולה לשמש בהצלחה כמאגר 
 #: welcome.strnosongrepoyet
 msgid "Please select a song repository path before you leave the assistent. Cantara can not work without it."
 msgstr "נא לבחור נתיב למאגר השירים לפני היציאה מהעוזר. Cantara לא יכול לפעול בלעדיו."
+

--- a/src/locals/cantara.id.po
+++ b/src/locals/cantara.id.po
@@ -580,7 +580,7 @@ msgstr "Transisi pudar antar slide"
 
 #: tfrmsettings.cbhidecursorinpresentation.caption
 msgid "Hide mouse cursor in presentation mode"
-msgstr ""
+msgstr "Sembunyikan kursor mouse dalam mode presentasi"
 
 #: tfrmsettings.cbmetadatafirstslide.caption
 msgid "at first slide"

--- a/src/locals/cantara.id.po
+++ b/src/locals/cantara.id.po
@@ -208,7 +208,9 @@ msgid "Hint"
 msgstr "Petunjuk"
 
 #: songselection.strpptxgenjs
-msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs[](https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
+#, fuzzy
+#| msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs[](https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
+msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs (https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
 msgstr "Cantara menggunakan mesin JavaScript dari browser web default lokal Anda dan pustaka JavaScript open source PptxGenJs[](https://gitbrent.github.io/PptxGenJS/) untuk menghasilkan file pptx. Oleh karena itu, setelah menekan OK, browser web Anda akan terbuka dan meminta tempat untuk menyimpan file pptx setelah pembuatan selesai dengan sukses. Selama proses ini, tidak diperlukan koneksi internet dan tidak ada data yang dibagikan kepada pihak lain selain browser Anda. Jika ingin melanjutkan, tekan OK (pesan ini tidak akan muncul lagi di lain waktu). Jika tidak ingin melanjutkan, tekan Batal."
 
 #: songselection.strsongisempty
@@ -768,6 +770,10 @@ msgctxt "tfrmsongs.btnstartpresentation.caption"
 msgid "Presentation..."
 msgstr "Presentasi…"
 
+#: tfrmsongs.btntoggleblack.caption
+msgid "■"
+msgstr ""
+
 #: tfrmsongs.btnup.caption
 msgid "🠕"
 msgstr "🠕"
@@ -1069,3 +1075,4 @@ msgstr "Direktori yang dipilih dapat digunakan dengan sukses sebagai repositori 
 #: welcome.strnosongrepoyet
 msgid "Please select a song repository path before you leave the assistent. Cantara can not work without it."
 msgstr "Silakan pilih jalur repositori lagu sebelum meninggalkan asisten. Cantara tidak dapat bekerja tanpanya."
+

--- a/src/locals/cantara.id.po
+++ b/src/locals/cantara.id.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cantara\n"
 "POT-Creation-Date: \n"
-"PO-Revision-Date: 2026-02-21\n"
-"Last-Translator: \n"
+"PO-Revision-Date: 2026-07-08 18:32\n"
+"Last-Translator: Jan Martin Reckel <jm.reckel@t-online.de>\n"
 "Language-Team: Bahasa Indonesia\n"
 "Language: id\n"
 "MIME-Version: 1.0\n"
@@ -208,8 +208,6 @@ msgid "Hint"
 msgstr "Petunjuk"
 
 #: songselection.strpptxgenjs
-#, fuzzy
-#| msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs[](https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
 msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs (https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
 msgstr "Cantara menggunakan mesin JavaScript dari browser web default lokal Anda dan pustaka JavaScript open source PptxGenJs[](https://gitbrent.github.io/PptxGenJS/) untuk menghasilkan file pptx. Oleh karena itu, setelah menekan OK, browser web Anda akan terbuka dan meminta tempat untuk menyimpan file pptx setelah pembuatan selesai dengan sukses. Selama proses ini, tidak diperlukan koneksi internet dan tidak ada data yang dibagikan kepada pihak lain selain browser Anda. Jika ingin melanjutkan, tekan OK (pesan ini tidak akan muncul lagi di lain waktu). Jika tidak ingin melanjutkan, tekan Batal."
 
@@ -526,7 +524,6 @@ msgid "Open image file"
 msgstr "Buka file gambar"
 
 #: tfrmsettings.bgpicturefiledialog.title
-#, fuzzy
 msgctxt "tfrmsettings.bgpicturefiledialog.title"
 msgid "Open image file"
 msgstr "Buka file gambar"
@@ -783,8 +780,6 @@ msgid "Close File"
 msgstr "Tutup File"
 
 #: tfrmsongs.caption
-#, fuzzy
-#| msgid "Song Selection (Cantara)"
 msgctxt "tfrmsongs.caption"
 msgid "Cantara"
 msgstr "Cantara"

--- a/src/locals/cantara.id.po
+++ b/src/locals/cantara.id.po
@@ -576,6 +576,10 @@ msgstr "Slide kosong di antara lagu"
 msgid "Fade transition between slides"
 msgstr "Transisi pudar antar slide"
 
+#: tfrmsettings.cbhidecursorinpresentation.caption
+msgid "Hide mouse cursor in presentation mode"
+msgstr ""
+
 #: tfrmsettings.cbmetadatafirstslide.caption
 msgid "at first slide"
 msgstr "pada slide pertama"

--- a/src/locals/cantara.it.po
+++ b/src/locals/cantara.it.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cantara\n"
 "POT-Creation-Date: \n"
-"PO-Revision-Date: \n"
+"PO-Revision-Date: 2026-07-08 18:32\n"
 "Last-Translator: Jan Martin Reckel <jm.reckel@t-online.de>\n"
 "Language-Team: Albano Battistella <albano_battistella@hotmail.com>\n"
 "Language: it_IT\n"
@@ -208,8 +208,6 @@ msgid "Hint"
 msgstr "Suggerimento"
 
 #: songselection.strpptxgenjs
-#, fuzzy
-#| msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs[](https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
 msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs (https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
 msgstr "Cantara utilizza il motore JavaScript del tuo browser web predefinito e la libreria open source PptxGenJS[](https://gitbrent.github.io/PptxGenJS/) per generare il file pptx. Dopo aver premuto OK, il browser si aprirà e ti chiederà dove salvare il file pptx una volta completata la generazione con successo. Durante questo processo non è necessaria alcuna connessione Internet e nessun dato viene condiviso con terzi tramite il browser. Se vuoi continuare premi OK (questo messaggio non riapparirà più in futuro). Altrimenti premi Annulla."
 
@@ -526,7 +524,6 @@ msgid "Open image file"
 msgstr "Apri file immagine"
 
 #: tfrmsettings.bgpicturefiledialog.title
-#, fuzzy
 msgctxt "tfrmsettings.bgpicturefiledialog.title"
 msgid "Open image file"
 msgstr "Apri file immagine"
@@ -783,8 +780,6 @@ msgid "Close File"
 msgstr "Chiudi file"
 
 #: tfrmsongs.caption
-#, fuzzy
-#| msgid "Song Selection (Cantara)"
 msgctxt "tfrmsongs.caption"
 msgid "Cantara"
 msgstr "Cantara"

--- a/src/locals/cantara.it.po
+++ b/src/locals/cantara.it.po
@@ -208,7 +208,9 @@ msgid "Hint"
 msgstr "Suggerimento"
 
 #: songselection.strpptxgenjs
-msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs[](https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
+#, fuzzy
+#| msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs[](https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
+msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs (https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
 msgstr "Cantara utilizza il motore JavaScript del tuo browser web predefinito e la libreria open source PptxGenJS[](https://gitbrent.github.io/PptxGenJS/) per generare il file pptx. Dopo aver premuto OK, il browser si aprirà e ti chiederà dove salvare il file pptx una volta completata la generazione con successo. Durante questo processo non è necessaria alcuna connessione Internet e nessun dato viene condiviso con terzi tramite il browser. Se vuoi continuare premi OK (questo messaggio non riapparirà più in futuro). Altrimenti premi Annulla."
 
 #: songselection.strsongisempty
@@ -768,6 +770,10 @@ msgctxt "tfrmsongs.btnstartpresentation.caption"
 msgid "Presentation..."
 msgstr "Presentazione..."
 
+#: tfrmsongs.btntoggleblack.caption
+msgid "■"
+msgstr ""
+
 #: tfrmsongs.btnup.caption
 msgid "🠕"
 msgstr "🠕"
@@ -1069,3 +1075,4 @@ msgstr "La directory selezionata può essere usata correttamente come repository
 #: welcome.strnosongrepoyet
 msgid "Please select a song repository path before you leave the assistent. Cantara can not work without it."
 msgstr "Seleziona un percorso per il repository dei brani prima di uscire dall'assistente. Cantara non può funzionare senza."
+

--- a/src/locals/cantara.it.po
+++ b/src/locals/cantara.it.po
@@ -576,6 +576,10 @@ msgstr "Diapositiva vuota tra i brani"
 msgid "Fade transition between slides"
 msgstr "Transizione dissolvenza tra diapositive"
 
+#: tfrmsettings.cbhidecursorinpresentation.caption
+msgid "Hide mouse cursor in presentation mode"
+msgstr ""
+
 #: tfrmsettings.cbmetadatafirstslide.caption
 msgid "at first slide"
 msgstr "nella prima diapositiva"

--- a/src/locals/cantara.it.po
+++ b/src/locals/cantara.it.po
@@ -580,7 +580,7 @@ msgstr "Transizione dissolvenza tra diapositive"
 
 #: tfrmsettings.cbhidecursorinpresentation.caption
 msgid "Hide mouse cursor in presentation mode"
-msgstr ""
+msgstr "Nascondi il cursore del mouse in modalità presentazione"
 
 #: tfrmsettings.cbmetadatafirstslide.caption
 msgid "at first slide"

--- a/src/locals/cantara.ja.po
+++ b/src/locals/cantara.ja.po
@@ -580,7 +580,7 @@ msgstr "スライド間のフェード遷移"
 
 #: tfrmsettings.cbhidecursorinpresentation.caption
 msgid "Hide mouse cursor in presentation mode"
-msgstr ""
+msgstr "プレゼンテーションモードでマウスカーソルを非表示にする"
 
 #: tfrmsettings.cbmetadatafirstslide.caption
 msgid "at first slide"

--- a/src/locals/cantara.ja.po
+++ b/src/locals/cantara.ja.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cantara\n"
 "POT-Creation-Date: \n"
-"PO-Revision-Date: 2026-02-21\n"
-"Last-Translator: \n"
+"PO-Revision-Date: 2026-07-08 18:32\n"
+"Last-Translator: Jan Martin Reckel <jm.reckel@t-online.de>\n"
 "Language-Team: Japanese\n"
 "Language: ja\n"
 "MIME-Version: 1.0\n"
@@ -208,8 +208,6 @@ msgid "Hint"
 msgstr "ヒント"
 
 #: songselection.strpptxgenjs
-#, fuzzy
-#| msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs[](https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
 msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs (https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
 msgstr "Cantaraはpptxファイル生成のため、ローカルの既定ウェブブラウザのJavaScriptエンジンとオープンソースのJavaScriptライブラリPptxGenJS（https://gitbrent.github.io/PptxGenJS/）を使用しています。「OK」を押すとブラウザが開き、生成完了後にpptxファイルの保存場所を尋ねます。この処理中はインターネット接続は不要で、ブラウザ以外にデータは一切共有されません。続行する場合は「OK」を押してください（次回からはこのメッセージは表示されません）。続行しない場合は「キャンセル」を押してください。"
 
@@ -526,7 +524,6 @@ msgid "Open image file"
 msgstr "画像ファイルを開く"
 
 #: tfrmsettings.bgpicturefiledialog.title
-#, fuzzy
 msgctxt "tfrmsettings.bgpicturefiledialog.title"
 msgid "Open image file"
 msgstr "画像ファイルを開く"
@@ -783,8 +780,6 @@ msgid "Close File"
 msgstr "ファイルを閉じる"
 
 #: tfrmsongs.caption
-#, fuzzy
-#| msgid "Song Selection (Cantara)"
 msgctxt "tfrmsongs.caption"
 msgid "Cantara"
 msgstr "Cantara"

--- a/src/locals/cantara.ja.po
+++ b/src/locals/cantara.ja.po
@@ -576,6 +576,10 @@ msgstr "曲の間に空のスライド"
 msgid "Fade transition between slides"
 msgstr "スライド間のフェード遷移"
 
+#: tfrmsettings.cbhidecursorinpresentation.caption
+msgid "Hide mouse cursor in presentation mode"
+msgstr ""
+
 #: tfrmsettings.cbmetadatafirstslide.caption
 msgid "at first slide"
 msgstr "最初のスライドで"

--- a/src/locals/cantara.ja.po
+++ b/src/locals/cantara.ja.po
@@ -208,7 +208,9 @@ msgid "Hint"
 msgstr "ヒント"
 
 #: songselection.strpptxgenjs
-msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs[](https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
+#, fuzzy
+#| msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs[](https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
+msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs (https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
 msgstr "Cantaraはpptxファイル生成のため、ローカルの既定ウェブブラウザのJavaScriptエンジンとオープンソースのJavaScriptライブラリPptxGenJS（https://gitbrent.github.io/PptxGenJS/）を使用しています。「OK」を押すとブラウザが開き、生成完了後にpptxファイルの保存場所を尋ねます。この処理中はインターネット接続は不要で、ブラウザ以外にデータは一切共有されません。続行する場合は「OK」を押してください（次回からはこのメッセージは表示されません）。続行しない場合は「キャンセル」を押してください。"
 
 #: songselection.strsongisempty
@@ -768,6 +770,10 @@ msgctxt "tfrmsongs.btnstartpresentation.caption"
 msgid "Presentation..."
 msgstr "プレゼンテーション…"
 
+#: tfrmsongs.btntoggleblack.caption
+msgid "■"
+msgstr ""
+
 #: tfrmsongs.btnup.caption
 msgid "🠕"
 msgstr "🠕"
@@ -1069,3 +1075,4 @@ msgstr "選択したフォルダを曲リポジトリとして正常に使用で
 #: welcome.strnosongrepoyet
 msgid "Please select a song repository path before you leave the assistent. Cantara can not work without it."
 msgstr "アシスタントを終了する前に曲リポジトリのパスを選択してください。それがないとCantaraは動作しません。"
+

--- a/src/locals/cantara.kr.po
+++ b/src/locals/cantara.kr.po
@@ -576,6 +576,10 @@ msgstr "곡 사이에 빈 슬라이드"
 msgid "Fade transition between slides"
 msgstr "슬라이드 간 페이드 전환"
 
+#: tfrmsettings.cbhidecursorinpresentation.caption
+msgid "Hide mouse cursor in presentation mode"
+msgstr ""
+
 #: tfrmsettings.cbmetadatafirstslide.caption
 msgid "at first slide"
 msgstr "첫 슬라이드에"

--- a/src/locals/cantara.kr.po
+++ b/src/locals/cantara.kr.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cantara\n"
 "POT-Creation-Date: \n"
-"PO-Revision-Date: 2026-02-21\n"
-"Last-Translator: \n"
+"PO-Revision-Date: 2026-07-08 18:32\n"
+"Last-Translator: Jan Martin Reckel <jm.reckel@t-online.de>\n"
 "Language-Team: Korean\n"
 "Language: ko\n"
 "MIME-Version: 1.0\n"
@@ -208,8 +208,6 @@ msgid "Hint"
 msgstr "힌트"
 
 #: songselection.strpptxgenjs
-#, fuzzy
-#| msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs[](https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
 msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs (https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
 msgstr "Cantara는 pptx 파일을 생성하기 위해 로컬 기본 웹 브라우저의 JavaScript 엔진과 오픈소스 JavaScript 라이브러리 PptxGenJS[](https://gitbrent.github.io/PptxGenJS/)를 사용합니다. 따라서 “확인”을 누르면 브라우저가 열리고 생성이 완료되면 pptx 파일을 저장할 위치를 묻습니다. 이 과정에서 인터넷 연결이 필요 없으며, 브라우저를 통한 데이터 공유도 없습니다. 계속하려면 “확인”을 누르세요(다음부터 이 메시지는 나타나지 않습니다). 취소하려면 “취소”를 누르세요."
 
@@ -526,7 +524,6 @@ msgid "Open image file"
 msgstr "이미지 파일 열기"
 
 #: tfrmsettings.bgpicturefiledialog.title
-#, fuzzy
 msgctxt "tfrmsettings.bgpicturefiledialog.title"
 msgid "Open image file"
 msgstr "이미지 파일 열기"
@@ -783,8 +780,6 @@ msgid "Close File"
 msgstr "파일 닫기"
 
 #: tfrmsongs.caption
-#, fuzzy
-#| msgid "Song Selection (Cantara)"
 msgctxt "tfrmsongs.caption"
 msgid "Cantara"
 msgstr "Cantara"

--- a/src/locals/cantara.kr.po
+++ b/src/locals/cantara.kr.po
@@ -208,7 +208,9 @@ msgid "Hint"
 msgstr "힌트"
 
 #: songselection.strpptxgenjs
-msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs[](https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
+#, fuzzy
+#| msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs[](https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
+msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs (https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
 msgstr "Cantara는 pptx 파일을 생성하기 위해 로컬 기본 웹 브라우저의 JavaScript 엔진과 오픈소스 JavaScript 라이브러리 PptxGenJS[](https://gitbrent.github.io/PptxGenJS/)를 사용합니다. 따라서 “확인”을 누르면 브라우저가 열리고 생성이 완료되면 pptx 파일을 저장할 위치를 묻습니다. 이 과정에서 인터넷 연결이 필요 없으며, 브라우저를 통한 데이터 공유도 없습니다. 계속하려면 “확인”을 누르세요(다음부터 이 메시지는 나타나지 않습니다). 취소하려면 “취소”를 누르세요."
 
 #: songselection.strsongisempty
@@ -768,6 +770,10 @@ msgctxt "tfrmsongs.btnstartpresentation.caption"
 msgid "Presentation..."
 msgstr "프레젠테이션…"
 
+#: tfrmsongs.btntoggleblack.caption
+msgid "■"
+msgstr ""
+
 #: tfrmsongs.btnup.caption
 msgid "🠕"
 msgstr "🠕"
@@ -1069,3 +1075,4 @@ msgstr "선택한 폴더를 곡 저장소로 성공적으로 사용할 수 있�
 #: welcome.strnosongrepoyet
 msgid "Please select a song repository path before you leave the assistent. Cantara can not work without it."
 msgstr "도우미를 종료하기 전에 곡 저장소 경로를 선택하세요. 이 경로 없이는 Cantara가 작동하지 않습니다."
+

--- a/src/locals/cantara.kr.po
+++ b/src/locals/cantara.kr.po
@@ -580,7 +580,7 @@ msgstr "슬라이드 간 페이드 전환"
 
 #: tfrmsettings.cbhidecursorinpresentation.caption
 msgid "Hide mouse cursor in presentation mode"
-msgstr ""
+msgstr "프레젠테이션 모드에서 마우스 커서 숨기기"
 
 #: tfrmsettings.cbmetadatafirstslide.caption
 msgid "at first slide"

--- a/src/locals/cantara.nl.po
+++ b/src/locals/cantara.nl.po
@@ -579,7 +579,7 @@ msgstr ""
 
 #: tfrmsettings.cbhidecursorinpresentation.caption
 msgid "Hide mouse cursor in presentation mode"
-msgstr ""
+msgstr "Muiscursor verbergen in presentatiemodus"
 
 #: tfrmsettings.cbmetadatafirstslide.caption
 msgid "at first slide"

--- a/src/locals/cantara.nl.po
+++ b/src/locals/cantara.nl.po
@@ -3,8 +3,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "POT-Creation-Date: \n"
-"PO-Revision-Date: 2026-02-21 09:00+0100\n"
-"Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
+"PO-Revision-Date: 2026-07-08 18:32\n"
+"Last-Translator: Jan Martin Reckel <jm.reckel@t-online.de>\n"
 "Language-Team: Dutch\n"
 "Language: nl\n"
 "MIME-Version: 1.0\n"
@@ -525,7 +525,6 @@ msgid "Open image file"
 msgstr "Afbeelding openen"
 
 #: tfrmsettings.bgpicturefiledialog.title
-#, fuzzy
 msgctxt "tfrmsettings.bgpicturefiledialog.title"
 msgid "Open image file"
 msgstr "Afbeelding openen"
@@ -782,8 +781,6 @@ msgid "Close File"
 msgstr "Bestand sluiten"
 
 #: tfrmsongs.caption
-#, fuzzy
-#| msgid "Song Selection (Cantara)"
 msgctxt "tfrmsongs.caption"
 msgid "Cantara"
 msgstr "Cantara"

--- a/src/locals/cantara.nl.po
+++ b/src/locals/cantara.nl.po
@@ -565,9 +565,17 @@ msgctxt "tfrmsettings.caption"
 msgid "Settings"
 msgstr "Instellingen"
 
+#: tfrmsettings.cbblackscreenonempty.caption
+msgid "Show black screen when slide is empty"
+msgstr ""
+
 #: tfrmsettings.cbemptyframe.caption
 msgid "Empty slide between songs"
 msgstr "Pauze tussen nummers"
+
+#: tfrmsettings.cbfadetransition.caption
+msgid "Fade transition between slides"
+msgstr ""
 
 #: tfrmsettings.cbhidecursorinpresentation.caption
 msgid "Hide mouse cursor in presentation mode"
@@ -612,6 +620,10 @@ msgstr "Locatie van nummer:"
 #: tfrmsettings.lblalignment.caption
 msgid "Alignment: "
 msgstr "Uitlijning: "
+
+#: tfrmsettings.lblfadems.caption
+msgid "ms"
+msgstr ""
 
 #: tfrmsettings.lblimagebrightness.caption
 msgid "Change Image Transparency:"
@@ -756,6 +768,10 @@ msgstr "Instellingen…"
 msgctxt "tfrmsongs.btnstartpresentation.caption"
 msgid "Presentation..."
 msgstr "Presentatie…"
+
+#: tfrmsongs.btntoggleblack.caption
+msgid "■"
+msgstr ""
 
 #: tfrmsongs.btnup.caption
 msgid "🠕"

--- a/src/locals/cantara.nl.po
+++ b/src/locals/cantara.nl.po
@@ -569,6 +569,10 @@ msgstr "Instellingen"
 msgid "Empty slide between songs"
 msgstr "Pauze tussen nummers"
 
+#: tfrmsettings.cbhidecursorinpresentation.caption
+msgid "Hide mouse cursor in presentation mode"
+msgstr ""
+
 #: tfrmsettings.cbmetadatafirstslide.caption
 msgid "at first slide"
 msgstr "na eerste dia"

--- a/src/locals/cantara.pl.po
+++ b/src/locals/cantara.pl.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cantara\n"
 "POT-Creation-Date: \n"
-"PO-Revision-Date: 2026-02-21\n"
-"Last-Translator: \n"
+"PO-Revision-Date: 2026-07-08 18:32\n"
+"Last-Translator: Jan Martin Reckel <jm.reckel@t-online.de>\n"
 "Language-Team: Polish\n"
 "Language: pl\n"
 "MIME-Version: 1.0\n"
@@ -208,8 +208,6 @@ msgid "Hint"
 msgstr "Wskazówka"
 
 #: songselection.strpptxgenjs
-#, fuzzy
-#| msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs[](https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
 msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs (https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
 msgstr "Cantara wykorzystuje silnik JavaScript Twojej domyślnej przeglądarki oraz otwartą bibliotekę JavaScript PptxGenJS[](https://gitbrent.github.io/PptxGenJS/), aby wygenerować plik pptx. Po naciśnięciu „OK” przeglądarka otworzy się i poprosi o miejsce zapisu pliku po zakończeniu generowania. W tym procesie nie jest wymagane połączenie z internetem i żadne dane nie są udostępniane nikomu poza Twoją przeglądarką. Jeśli chcesz kontynuować, naciśnij „OK” (wiadomość nie pojawi się ponownie). Jeśli nie chcesz kontynuować, naciśnij „Anuluj”."
 
@@ -526,7 +524,6 @@ msgid "Open image file"
 msgstr "Otwórz plik obrazu"
 
 #: tfrmsettings.bgpicturefiledialog.title
-#, fuzzy
 msgctxt "tfrmsettings.bgpicturefiledialog.title"
 msgid "Open image file"
 msgstr "Otwórz plik obrazu"
@@ -783,8 +780,6 @@ msgid "Close File"
 msgstr "Zamknij plik"
 
 #: tfrmsongs.caption
-#, fuzzy
-#| msgid "Song Selection (Cantara)"
 msgctxt "tfrmsongs.caption"
 msgid "Cantara"
 msgstr "Cantara"

--- a/src/locals/cantara.pl.po
+++ b/src/locals/cantara.pl.po
@@ -580,7 +580,7 @@ msgstr "Płynne przejście między slajdami"
 
 #: tfrmsettings.cbhidecursorinpresentation.caption
 msgid "Hide mouse cursor in presentation mode"
-msgstr ""
+msgstr "Ukryj kursor myszy w trybie prezentacji"
 
 #: tfrmsettings.cbmetadatafirstslide.caption
 msgid "at first slide"

--- a/src/locals/cantara.pl.po
+++ b/src/locals/cantara.pl.po
@@ -208,7 +208,9 @@ msgid "Hint"
 msgstr "Wskazówka"
 
 #: songselection.strpptxgenjs
-msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs[](https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
+#, fuzzy
+#| msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs[](https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
+msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs (https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
 msgstr "Cantara wykorzystuje silnik JavaScript Twojej domyślnej przeglądarki oraz otwartą bibliotekę JavaScript PptxGenJS[](https://gitbrent.github.io/PptxGenJS/), aby wygenerować plik pptx. Po naciśnięciu „OK” przeglądarka otworzy się i poprosi o miejsce zapisu pliku po zakończeniu generowania. W tym procesie nie jest wymagane połączenie z internetem i żadne dane nie są udostępniane nikomu poza Twoją przeglądarką. Jeśli chcesz kontynuować, naciśnij „OK” (wiadomość nie pojawi się ponownie). Jeśli nie chcesz kontynuować, naciśnij „Anuluj”."
 
 #: songselection.strsongisempty
@@ -768,6 +770,10 @@ msgctxt "tfrmsongs.btnstartpresentation.caption"
 msgid "Presentation..."
 msgstr "Prezentacja…"
 
+#: tfrmsongs.btntoggleblack.caption
+msgid "■"
+msgstr ""
+
 #: tfrmsongs.btnup.caption
 msgid "🠕"
 msgstr "🠕"
@@ -1069,3 +1075,4 @@ msgstr "Wybrany katalog może być z powodzeniem używany jako repozytorium pie�
 #: welcome.strnosongrepoyet
 msgid "Please select a song repository path before you leave the assistent. Cantara can not work without it."
 msgstr "Proszę wybrać ścieżkę do repozytorium pieśni zanim opuścisz kreator. Bez tego Cantara nie będzie działać."
+

--- a/src/locals/cantara.pl.po
+++ b/src/locals/cantara.pl.po
@@ -576,6 +576,10 @@ msgstr "Pusty slajd między pieśniami"
 msgid "Fade transition between slides"
 msgstr "Płynne przejście między slajdami"
 
+#: tfrmsettings.cbhidecursorinpresentation.caption
+msgid "Hide mouse cursor in presentation mode"
+msgstr ""
+
 #: tfrmsettings.cbmetadatafirstslide.caption
 msgid "at first slide"
 msgstr "na pierwszym slajdzie"

--- a/src/locals/cantara.pot
+++ b/src/locals/cantara.pot
@@ -543,6 +543,10 @@ msgstr ""
 msgid "Fade transition between slides"
 msgstr ""
 
+#: tfrmsettings.cbhidecursorinpresentation.caption
+msgid "Hide mouse cursor in presentation mode"
+msgstr ""
+
 #: tfrmsettings.cbmetadatafirstslide.caption
 msgid "at first slide"
 msgstr ""

--- a/src/locals/cantara.pot
+++ b/src/locals/cantara.pot
@@ -735,6 +735,10 @@ msgctxt "tfrmsongs.btnstartpresentation.caption"
 msgid "Presentation..."
 msgstr ""
 
+#: tfrmsongs.btntoggleblack.caption
+msgid "■"
+msgstr ""
+
 #: tfrmsongs.btnup.caption
 msgid "🠕"
 msgstr ""

--- a/src/locals/cantara.pt.po
+++ b/src/locals/cantara.pt.po
@@ -580,7 +580,7 @@ msgstr "Transição de esmaecimento entre slides"
 
 #: tfrmsettings.cbhidecursorinpresentation.caption
 msgid "Hide mouse cursor in presentation mode"
-msgstr ""
+msgstr "Ocultar o cursor do mouse no modo de apresentação"
 
 #: tfrmsettings.cbmetadatafirstslide.caption
 msgid "at first slide"

--- a/src/locals/cantara.pt.po
+++ b/src/locals/cantara.pt.po
@@ -208,7 +208,9 @@ msgid "Hint"
 msgstr "Dica"
 
 #: songselection.strpptxgenjs
-msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs[](https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
+#, fuzzy
+#| msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs[](https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
+msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs (https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
 msgstr "O Cantara está usando o motor JavaScript do seu navegador web padrão local e a biblioteca JavaScript de código aberto PptxGenJs[](https://gitbrent.github.io/PptxGenJS/) para gerar o arquivo pptx. Portanto, após pressionar OK, seu navegador abrirá e perguntará onde salvar o arquivo pptx quando a geração for concluída com sucesso. Durante esse processo, não é necessária conexão com a internet e nenhum dado é compartilhado com ninguém além do seu navegador. Se quiser continuar, pressione OK (esta mensagem não aparecerá novamente nas próximas vezes). Se não quiser continuar, pressione Cancelar."
 
 #: songselection.strsongisempty
@@ -768,6 +770,10 @@ msgctxt "tfrmsongs.btnstartpresentation.caption"
 msgid "Presentation..."
 msgstr "Apresentação…"
 
+#: tfrmsongs.btntoggleblack.caption
+msgid "■"
+msgstr ""
+
 #: tfrmsongs.btnup.caption
 msgid "🠕"
 msgstr "🠕"
@@ -1069,3 +1075,4 @@ msgstr "O diretório selecionado pode ser usado com sucesso como repositório de
 #: welcome.strnosongrepoyet
 msgid "Please select a song repository path before you leave the assistent. Cantara can not work without it."
 msgstr "Por favor, selecione o caminho do repositório de músicas antes de sair do assistente. O Cantara não funciona sem ele."
+

--- a/src/locals/cantara.pt.po
+++ b/src/locals/cantara.pt.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cantara\n"
 "POT-Creation-Date: \n"
-"PO-Revision-Date: 2026-02-21\n"
-"Last-Translator: \n"
+"PO-Revision-Date: 2026-07-08 18:32\n"
+"Last-Translator: Jan Martin Reckel <jm.reckel@t-online.de>\n"
 "Language-Team: Portuguese (Brazil)\n"
 "Language: pt_BR\n"
 "MIME-Version: 1.0\n"
@@ -208,8 +208,6 @@ msgid "Hint"
 msgstr "Dica"
 
 #: songselection.strpptxgenjs
-#, fuzzy
-#| msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs[](https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
 msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs (https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
 msgstr "O Cantara está usando o motor JavaScript do seu navegador web padrão local e a biblioteca JavaScript de código aberto PptxGenJs[](https://gitbrent.github.io/PptxGenJS/) para gerar o arquivo pptx. Portanto, após pressionar OK, seu navegador abrirá e perguntará onde salvar o arquivo pptx quando a geração for concluída com sucesso. Durante esse processo, não é necessária conexão com a internet e nenhum dado é compartilhado com ninguém além do seu navegador. Se quiser continuar, pressione OK (esta mensagem não aparecerá novamente nas próximas vezes). Se não quiser continuar, pressione Cancelar."
 
@@ -526,7 +524,6 @@ msgid "Open image file"
 msgstr "Abrir arquivo de imagem"
 
 #: tfrmsettings.bgpicturefiledialog.title
-#, fuzzy
 msgctxt "tfrmsettings.bgpicturefiledialog.title"
 msgid "Open image file"
 msgstr "Abrir arquivo de imagem"
@@ -783,8 +780,6 @@ msgid "Close File"
 msgstr "Fechar arquivo"
 
 #: tfrmsongs.caption
-#, fuzzy
-#| msgid "Song Selection (Cantara)"
 msgctxt "tfrmsongs.caption"
 msgid "Cantara"
 msgstr "Cantara"

--- a/src/locals/cantara.pt.po
+++ b/src/locals/cantara.pt.po
@@ -576,6 +576,10 @@ msgstr "Slide vazio entre músicas"
 msgid "Fade transition between slides"
 msgstr "Transição de esmaecimento entre slides"
 
+#: tfrmsettings.cbhidecursorinpresentation.caption
+msgid "Hide mouse cursor in presentation mode"
+msgstr ""
+
 #: tfrmsettings.cbmetadatafirstslide.caption
 msgid "at first slide"
 msgstr "no primeiro slide"

--- a/src/locals/cantara.ru.po
+++ b/src/locals/cantara.ru.po
@@ -576,6 +576,10 @@ msgstr "Пустой слайд между песнями"
 msgid "Fade transition between slides"
 msgstr "Плавный переход между слайдами"
 
+#: tfrmsettings.cbhidecursorinpresentation.caption
+msgid "Hide mouse cursor in presentation mode"
+msgstr ""
+
 #: tfrmsettings.cbmetadatafirstslide.caption
 msgid "at first slide"
 msgstr "на первом слайде"

--- a/src/locals/cantara.ru.po
+++ b/src/locals/cantara.ru.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cantara\n"
 "POT-Creation-Date: \n"
-"PO-Revision-Date: 2026-02-21\n"
-"Last-Translator: \n"
+"PO-Revision-Date: 2026-07-08 18:32\n"
+"Last-Translator: Jan Martin Reckel <jm.reckel@t-online.de>\n"
 "Language-Team: Russian\n"
 "Language: ru\n"
 "MIME-Version: 1.0\n"
@@ -208,8 +208,6 @@ msgid "Hint"
 msgstr "Подсказка"
 
 #: songselection.strpptxgenjs
-#, fuzzy
-#| msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs[](https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
 msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs (https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
 msgstr "Cantara использует JavaScript-движок вашего браузера по умолчанию и открытую библиотеку PptxGenJS[](https://gitbrent.github.io/PptxGenJS/) для создания файла pptx. После нажатия OK браузер откроется и предложит место для сохранения файла после успешной генерации. Интернет-соединение не требуется, и никакие данные не передаются третьим лицам (кроме вашего браузера). Чтобы продолжить — нажмите OK (сообщение больше не появится). Чтобы отменить — нажмите Отмена."
 
@@ -526,7 +524,6 @@ msgid "Open image file"
 msgstr "Открыть файл изображения"
 
 #: tfrmsettings.bgpicturefiledialog.title
-#, fuzzy
 msgctxt "tfrmsettings.bgpicturefiledialog.title"
 msgid "Open image file"
 msgstr "Открыть файл изображения"
@@ -783,8 +780,6 @@ msgid "Close File"
 msgstr "Закрыть файл"
 
 #: tfrmsongs.caption
-#, fuzzy
-#| msgid "Song Selection (Cantara)"
 msgctxt "tfrmsongs.caption"
 msgid "Cantara"
 msgstr "Cantara"

--- a/src/locals/cantara.ru.po
+++ b/src/locals/cantara.ru.po
@@ -208,7 +208,9 @@ msgid "Hint"
 msgstr "Подсказка"
 
 #: songselection.strpptxgenjs
-msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs[](https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
+#, fuzzy
+#| msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs[](https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
+msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs (https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
 msgstr "Cantara использует JavaScript-движок вашего браузера по умолчанию и открытую библиотеку PptxGenJS[](https://gitbrent.github.io/PptxGenJS/) для создания файла pptx. После нажатия OK браузер откроется и предложит место для сохранения файла после успешной генерации. Интернет-соединение не требуется, и никакие данные не передаются третьим лицам (кроме вашего браузера). Чтобы продолжить — нажмите OK (сообщение больше не появится). Чтобы отменить — нажмите Отмена."
 
 #: songselection.strsongisempty
@@ -768,6 +770,10 @@ msgctxt "tfrmsongs.btnstartpresentation.caption"
 msgid "Presentation..."
 msgstr "Презентация…"
 
+#: tfrmsongs.btntoggleblack.caption
+msgid "■"
+msgstr ""
+
 #: tfrmsongs.btnup.caption
 msgid "🠕"
 msgstr "🠕"
@@ -1069,3 +1075,4 @@ msgstr "Выбранная папка успешно может использо
 #: welcome.strnosongrepoyet
 msgid "Please select a song repository path before you leave the assistent. Cantara can not work without it."
 msgstr "Пожалуйста, выберите путь к репозиторию песен перед выходом из помощника. Без него Cantara не сможет работать."
+

--- a/src/locals/cantara.ru.po
+++ b/src/locals/cantara.ru.po
@@ -580,7 +580,7 @@ msgstr "Плавный переход между слайдами"
 
 #: tfrmsettings.cbhidecursorinpresentation.caption
 msgid "Hide mouse cursor in presentation mode"
-msgstr ""
+msgstr "Скрыть курсор мыши в режиме презентации"
 
 #: tfrmsettings.cbmetadatafirstslide.caption
 msgid "at first slide"

--- a/src/locals/cantara.tr.po
+++ b/src/locals/cantara.tr.po
@@ -576,6 +576,10 @@ msgstr "Şarkılar arasında boş slayt"
 msgid "Fade transition between slides"
 msgstr "Slaytlar arasında soluklaşma geçişi"
 
+#: tfrmsettings.cbhidecursorinpresentation.caption
+msgid "Hide mouse cursor in presentation mode"
+msgstr ""
+
 #: tfrmsettings.cbmetadatafirstslide.caption
 msgid "at first slide"
 msgstr "ilk slaytta"

--- a/src/locals/cantara.tr.po
+++ b/src/locals/cantara.tr.po
@@ -208,7 +208,9 @@ msgid "Hint"
 msgstr "İpucu"
 
 #: songselection.strpptxgenjs
-msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs[](https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
+#, fuzzy
+#| msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs[](https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
+msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs (https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
 msgstr "Cantara, pptx dosyasını oluşturmak için yerel varsayılan web tarayıcınızın JavaScript motorunu ve açık kaynaklı PptxGenJS kütüphanesini[](https://gitbrent.github.io/PptxGenJS/) kullanıyor. Bu nedenle “Tamam”a bastıktan sonra tarayıcınız açılacak ve oluşturma başarılı olduğunda pptx dosyasını kaydetmek için bir yer soracak. Bu süreçte internet bağlantısına ihtiyaç duyulmaz ve tarayıcınız dışında kimseyle veri paylaşılmaz. Devam etmek isterseniz “Tamam”a basın; bu mesaj bir daha görünmeyecek. Devam etmek istemiyorsanız “İptal”e basın."
 
 #: songselection.strsongisempty
@@ -768,6 +770,10 @@ msgctxt "tfrmsongs.btnstartpresentation.caption"
 msgid "Presentation..."
 msgstr "Sunum…"
 
+#: tfrmsongs.btntoggleblack.caption
+msgid "■"
+msgstr ""
+
 #: tfrmsongs.btnup.caption
 msgid "🠕"
 msgstr "🠕"
@@ -1069,3 +1075,4 @@ msgstr "Seçilen klasör başarıyla şarkı deposu olarak kullanılabilir."
 #: welcome.strnosongrepoyet
 msgid "Please select a song repository path before you leave the assistent. Cantara can not work without it."
 msgstr "Yardımcıyı kapatmadan önce lütfen şarkı deposu yolunu seçin. Onsuz Cantara çalışamaz."
+

--- a/src/locals/cantara.tr.po
+++ b/src/locals/cantara.tr.po
@@ -580,7 +580,7 @@ msgstr "Slaytlar arasında soluklaşma geçişi"
 
 #: tfrmsettings.cbhidecursorinpresentation.caption
 msgid "Hide mouse cursor in presentation mode"
-msgstr ""
+msgstr "Sunum modunda fare imlecini gizle"
 
 #: tfrmsettings.cbmetadatafirstslide.caption
 msgid "at first slide"

--- a/src/locals/cantara.tr.po
+++ b/src/locals/cantara.tr.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cantara\n"
 "POT-Creation-Date: \n"
-"PO-Revision-Date: 2026-02-21\n"
-"Last-Translator: \n"
+"PO-Revision-Date: 2026-07-08 18:32\n"
+"Last-Translator: Jan Martin Reckel <jm.reckel@t-online.de>\n"
 "Language-Team: Turkish\n"
 "Language: tr\n"
 "MIME-Version: 1.0\n"
@@ -208,8 +208,6 @@ msgid "Hint"
 msgstr "İpucu"
 
 #: songselection.strpptxgenjs
-#, fuzzy
-#| msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs[](https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
 msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs (https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
 msgstr "Cantara, pptx dosyasını oluşturmak için yerel varsayılan web tarayıcınızın JavaScript motorunu ve açık kaynaklı PptxGenJS kütüphanesini[](https://gitbrent.github.io/PptxGenJS/) kullanıyor. Bu nedenle “Tamam”a bastıktan sonra tarayıcınız açılacak ve oluşturma başarılı olduğunda pptx dosyasını kaydetmek için bir yer soracak. Bu süreçte internet bağlantısına ihtiyaç duyulmaz ve tarayıcınız dışında kimseyle veri paylaşılmaz. Devam etmek isterseniz “Tamam”a basın; bu mesaj bir daha görünmeyecek. Devam etmek istemiyorsanız “İptal”e basın."
 
@@ -526,7 +524,6 @@ msgid "Open image file"
 msgstr "Resim dosyasını aç"
 
 #: tfrmsettings.bgpicturefiledialog.title
-#, fuzzy
 msgctxt "tfrmsettings.bgpicturefiledialog.title"
 msgid "Open image file"
 msgstr "Resim dosyasını aç"
@@ -783,8 +780,6 @@ msgid "Close File"
 msgstr "Dosyayı Kapat"
 
 #: tfrmsongs.caption
-#, fuzzy
-#| msgid "Song Selection (Cantara)"
 msgctxt "tfrmsongs.caption"
 msgid "Cantara"
 msgstr "Cantara"

--- a/src/locals/cantara.uk.po
+++ b/src/locals/cantara.uk.po
@@ -580,7 +580,7 @@ msgstr "Плавний перехід між слайдами"
 
 #: tfrmsettings.cbhidecursorinpresentation.caption
 msgid "Hide mouse cursor in presentation mode"
-msgstr ""
+msgstr "Приховати курсор миші в режимі презентації"
 
 #: tfrmsettings.cbmetadatafirstslide.caption
 msgid "at first slide"

--- a/src/locals/cantara.uk.po
+++ b/src/locals/cantara.uk.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cantara\n"
 "POT-Creation-Date: \n"
-"PO-Revision-Date: 2026-02-21\n"
-"Last-Translator: \n"
+"PO-Revision-Date: 2026-07-08 18:32\n"
+"Last-Translator: Jan Martin Reckel <jm.reckel@t-online.de>\n"
 "Language-Team: Ukrainian\n"
 "Language: uk\n"
 "MIME-Version: 1.0\n"
@@ -208,8 +208,6 @@ msgid "Hint"
 msgstr "Підказка"
 
 #: songselection.strpptxgenjs
-#, fuzzy
-#| msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs[](https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
 msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs (https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
 msgstr "Cantara використовує JavaScript-двигун вашого браузера за замовчуванням та відкриту бібліотеку PptxGenJS[](https://gitbrent.github.io/PptxGenJS/), щоб створити файл pptx. Після натискання OK браузер відкриється та запропонує місце для збереження файлу після успішного створення. Під час процесу не потрібне підключення до Інтернету і жодні дані не передаються третім особам (окрім вашого браузера). Якщо хочете продовжити — натисніть OK (повідомлення більше не з’являтиметься). Якщо ні — натисніть Скасувати."
 
@@ -526,7 +524,6 @@ msgid "Open image file"
 msgstr "Відкрити файл зображення"
 
 #: tfrmsettings.bgpicturefiledialog.title
-#, fuzzy
 msgctxt "tfrmsettings.bgpicturefiledialog.title"
 msgid "Open image file"
 msgstr "Відкрити файл зображення"
@@ -783,8 +780,6 @@ msgid "Close File"
 msgstr "Закрити файл"
 
 #: tfrmsongs.caption
-#, fuzzy
-#| msgid "Song Selection (Cantara)"
 msgctxt "tfrmsongs.caption"
 msgid "Cantara"
 msgstr "Cantara"

--- a/src/locals/cantara.uk.po
+++ b/src/locals/cantara.uk.po
@@ -576,6 +576,10 @@ msgstr "Порожній слайд між піснями"
 msgid "Fade transition between slides"
 msgstr "Плавний перехід між слайдами"
 
+#: tfrmsettings.cbhidecursorinpresentation.caption
+msgid "Hide mouse cursor in presentation mode"
+msgstr ""
+
 #: tfrmsettings.cbmetadatafirstslide.caption
 msgid "at first slide"
 msgstr "на першому слайді"

--- a/src/locals/cantara.uk.po
+++ b/src/locals/cantara.uk.po
@@ -208,7 +208,9 @@ msgid "Hint"
 msgstr "Підказка"
 
 #: songselection.strpptxgenjs
-msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs[](https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
+#, fuzzy
+#| msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs[](https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
+msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs (https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
 msgstr "Cantara використовує JavaScript-двигун вашого браузера за замовчуванням та відкриту бібліотеку PptxGenJS[](https://gitbrent.github.io/PptxGenJS/), щоб створити файл pptx. Після натискання OK браузер відкриється та запропонує місце для збереження файлу після успішного створення. Під час процесу не потрібне підключення до Інтернету і жодні дані не передаються третім особам (окрім вашого браузера). Якщо хочете продовжити — натисніть OK (повідомлення більше не з’являтиметься). Якщо ні — натисніть Скасувати."
 
 #: songselection.strsongisempty
@@ -768,6 +770,10 @@ msgctxt "tfrmsongs.btnstartpresentation.caption"
 msgid "Presentation..."
 msgstr "Презентація…"
 
+#: tfrmsongs.btntoggleblack.caption
+msgid "■"
+msgstr ""
+
 #: tfrmsongs.btnup.caption
 msgid "🠕"
 msgstr "🠕"
@@ -1069,3 +1075,4 @@ msgstr "Вибрану теку успішно можна використову
 #: welcome.strnosongrepoyet
 msgid "Please select a song repository path before you leave the assistent. Cantara can not work without it."
 msgstr "Будь ласка, виберіть шлях до репозиторію пісень перед виходом з помічника. Без нього Cantara не працюватиме."
+

--- a/src/locals/cantara.vi.po
+++ b/src/locals/cantara.vi.po
@@ -208,7 +208,9 @@ msgid "Hint"
 msgstr "Gợi ý"
 
 #: songselection.strpptxgenjs
-msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs[](https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
+#, fuzzy
+#| msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs[](https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
+msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs (https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
 msgstr "Cantara sử dụng engine JavaScript của trình duyệt mặc định trên máy bạn và thư viện mã nguồn mở PptxGenJS[](https://gitbrent.github.io/PptxGenJS/) để tạo tệp pptx. Sau khi nhấn OK, trình duyệt sẽ mở ra và hỏi bạn nơi lưu tệp pptx sau khi tạo thành công. Quá trình này không cần kết nối internet và không chia sẻ dữ liệu với bất kỳ ai ngoài trình duyệt của bạn. Nếu muốn tiếp tục, nhấn OK (thông báo này sẽ không hiện lại lần sau). Nếu không muốn tiếp tục, nhấn Hủy."
 
 #: songselection.strsongisempty
@@ -768,6 +770,10 @@ msgctxt "tfrmsongs.btnstartpresentation.caption"
 msgid "Presentation..."
 msgstr "Trình chiếu…"
 
+#: tfrmsongs.btntoggleblack.caption
+msgid "■"
+msgstr ""
+
 #: tfrmsongs.btnup.caption
 msgid "🠕"
 msgstr "🠕"
@@ -1069,3 +1075,4 @@ msgstr "Thư mục đã chọn có thể được sử dụng thành công làm 
 #: welcome.strnosongrepoyet
 msgid "Please select a song repository path before you leave the assistent. Cantara can not work without it."
 msgstr "Vui lòng chọn đường dẫn kho bài hát trước khi rời khỏi trợ lý. Cantara không thể hoạt động nếu thiếu nó."
+

--- a/src/locals/cantara.vi.po
+++ b/src/locals/cantara.vi.po
@@ -580,7 +580,7 @@ msgstr "Hiệu ứng mờ dần giữa các slide"
 
 #: tfrmsettings.cbhidecursorinpresentation.caption
 msgid "Hide mouse cursor in presentation mode"
-msgstr ""
+msgstr "Ẩn con trỏ chuột trong chế độ trình chiếu"
 
 #: tfrmsettings.cbmetadatafirstslide.caption
 msgid "at first slide"

--- a/src/locals/cantara.vi.po
+++ b/src/locals/cantara.vi.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cantara\n"
 "POT-Creation-Date: \n"
-"PO-Revision-Date: 2026-02-21\n"
-"Last-Translator: \n"
+"PO-Revision-Date: 2026-07-08 18:32\n"
+"Last-Translator: Jan Martin Reckel <jm.reckel@t-online.de>\n"
 "Language-Team: Vietnamese\n"
 "Language: vi\n"
 "MIME-Version: 1.0\n"
@@ -208,8 +208,6 @@ msgid "Hint"
 msgstr "Gợi ý"
 
 #: songselection.strpptxgenjs
-#, fuzzy
-#| msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs[](https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
 msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs (https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
 msgstr "Cantara sử dụng engine JavaScript của trình duyệt mặc định trên máy bạn và thư viện mã nguồn mở PptxGenJS[](https://gitbrent.github.io/PptxGenJS/) để tạo tệp pptx. Sau khi nhấn OK, trình duyệt sẽ mở ra và hỏi bạn nơi lưu tệp pptx sau khi tạo thành công. Quá trình này không cần kết nối internet và không chia sẻ dữ liệu với bất kỳ ai ngoài trình duyệt của bạn. Nếu muốn tiếp tục, nhấn OK (thông báo này sẽ không hiện lại lần sau). Nếu không muốn tiếp tục, nhấn Hủy."
 
@@ -526,7 +524,6 @@ msgid "Open image file"
 msgstr "Mở tệp hình ảnh"
 
 #: tfrmsettings.bgpicturefiledialog.title
-#, fuzzy
 msgctxt "tfrmsettings.bgpicturefiledialog.title"
 msgid "Open image file"
 msgstr "Mở tệp hình ảnh"
@@ -783,8 +780,6 @@ msgid "Close File"
 msgstr "Đóng tệp"
 
 #: tfrmsongs.caption
-#, fuzzy
-#| msgid "Song Selection (Cantara)"
 msgctxt "tfrmsongs.caption"
 msgid "Cantara"
 msgstr "Cantara"

--- a/src/locals/cantara.vi.po
+++ b/src/locals/cantara.vi.po
@@ -576,6 +576,10 @@ msgstr "Slide trống giữa các bài hát"
 msgid "Fade transition between slides"
 msgstr "Hiệu ứng mờ dần giữa các slide"
 
+#: tfrmsettings.cbhidecursorinpresentation.caption
+msgid "Hide mouse cursor in presentation mode"
+msgstr ""
+
 #: tfrmsettings.cbmetadatafirstslide.caption
 msgid "at first slide"
 msgstr "ở slide đầu tiên"

--- a/src/locals/cantara.zh.po
+++ b/src/locals/cantara.zh.po
@@ -2,8 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "POT-Creation-Date: \n"
-"PO-Revision-Date: 2026-02-21 09:00+0100"
-"Last-Translator: Jan Martin Reckel <jm.reckel@t-online.de>\n"
+"PO-Revision-Date: 2026-02-21 09:00+0100Last-Translator: Jan Martin Reckel <jm.reckel@t-online.de>\n"
 "Language-Team: \n"
 "Language: zh_TW\n"
 "MIME-Version: 1.0\n"
@@ -208,7 +207,9 @@ msgid "Hint"
 msgstr "提示"
 
 #: songselection.strpptxgenjs
-msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs[](https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
+#, fuzzy
+#| msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs[](https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
+msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs (https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
 msgstr "Cantara 使用您本機預設網頁瀏覽器的 JavaScript 引擎及開源 JavaScript 程式庫 PptxGenJS[](https://gitbrent.github.io/PptxGenJS/) 來產生 pptx 檔案。因此，按下「確定」後，您的瀏覽器將開啟並在產生完成時詢問儲存位置。此過程無需網路連線，且除了您的瀏覽器外不會與任何人分享資料。若要繼續，請按「確定」，下次不會再顯示此訊息。若不想繼續，請按「取消」。"
 
 #: songselection.strsongisempty
@@ -768,6 +769,10 @@ msgctxt "tfrmsongs.btnstartpresentation.caption"
 msgid "Presentation..."
 msgstr "投影片..."
 
+#: tfrmsongs.btntoggleblack.caption
+msgid "■"
+msgstr ""
+
 #: tfrmsongs.btnup.caption
 msgid "🠕"
 msgstr "🠕"
@@ -1069,3 +1074,4 @@ msgstr "所選目錄可成功用作歌曲庫。"
 #: welcome.strnosongrepoyet
 msgid "Please select a song repository path before you leave the assistent. Cantara can not work without it."
 msgstr "離開助手前請選擇歌曲庫路徑。Cantara 沒有它無法運作。"
+

--- a/src/locals/cantara.zh.po
+++ b/src/locals/cantara.zh.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "POT-Creation-Date: \n"
-"PO-Revision-Date: 2026-02-21 09:00+0100Last-Translator: Jan Martin Reckel <jm.reckel@t-online.de>\n"
+"PO-Revision-Date: 2026-07-08 18:32\n"
 "Language-Team: \n"
 "Language: zh_TW\n"
 "MIME-Version: 1.0\n"
@@ -207,8 +207,6 @@ msgid "Hint"
 msgstr "提示"
 
 #: songselection.strpptxgenjs
-#, fuzzy
-#| msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs[](https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
 msgid "Cantara is using your local default web browser's Java Script engine and the open source Java Script library PptxGenJs (https://gitbrent.github.io/PptxGenJS/) to generate the pptx file. Therefore, after pressing OK, your web browser will open and ask you for a place to save the pptx file when the generation was done succesfully. During this process, no internet connection will be needed and no data is shared with anyone else despite your web browser. If you want to continue, press OK and this message won't show up again next time. If you don't want to continue, please press Cancel."
 msgstr "Cantara 使用您本機預設網頁瀏覽器的 JavaScript 引擎及開源 JavaScript 程式庫 PptxGenJS[](https://gitbrent.github.io/PptxGenJS/) 來產生 pptx 檔案。因此，按下「確定」後，您的瀏覽器將開啟並在產生完成時詢問儲存位置。此過程無需網路連線，且除了您的瀏覽器外不會與任何人分享資料。若要繼續，請按「確定」，下次不會再顯示此訊息。若不想繼續，請按「取消」。"
 
@@ -525,7 +523,6 @@ msgid "Open image file"
 msgstr "開啟圖片檔案"
 
 #: tfrmsettings.bgpicturefiledialog.title
-#, fuzzy
 msgctxt "tfrmsettings.bgpicturefiledialog.title"
 msgid "Open image file"
 msgstr "開啟圖片檔案"
@@ -782,8 +779,6 @@ msgid "Close File"
 msgstr "關閉檔案"
 
 #: tfrmsongs.caption
-#, fuzzy
-#| msgid "Song Selection (Cantara)"
 msgctxt "tfrmsongs.caption"
 msgid "Cantara"
 msgstr "Cantara"

--- a/src/locals/cantara.zh.po
+++ b/src/locals/cantara.zh.po
@@ -579,7 +579,7 @@ msgstr "投影片間淡入淡出轉場"
 
 #: tfrmsettings.cbhidecursorinpresentation.caption
 msgid "Hide mouse cursor in presentation mode"
-msgstr ""
+msgstr "在演示模式下隐藏鼠标光标"
 
 #: tfrmsettings.cbmetadatafirstslide.caption
 msgid "at first slide"

--- a/src/locals/cantara.zh.po
+++ b/src/locals/cantara.zh.po
@@ -576,7 +576,7 @@ msgstr "投影片間淡入淡出轉場"
 
 #: tfrmsettings.cbhidecursorinpresentation.caption
 msgid "Hide mouse cursor in presentation mode"
-msgstr "在演示模式下隐藏鼠标光标"
+msgstr "在演示模式下隱藏滑鼠游標"
 
 #: tfrmsettings.cbmetadatafirstslide.caption
 msgid "at first slide"

--- a/src/locals/cantara.zh.po
+++ b/src/locals/cantara.zh.po
@@ -576,6 +576,10 @@ msgstr "歌曲間插入空白投影片"
 msgid "Fade transition between slides"
 msgstr "投影片間淡入淡出轉場"
 
+#: tfrmsettings.cbhidecursorinpresentation.caption
+msgid "Hide mouse cursor in presentation mode"
+msgstr ""
+
 #: tfrmsettings.cbmetadatafirstslide.caption
 msgid "at first slide"
 msgstr "在第一張投影片"


### PR DESCRIPTION
This pull request adds a script to remove fuzzy translation strings from the po files which are automatically tagged as such by Lazarus when labels or other objects are getting modified.
As fuzzy tagged strings would normally be ignored by the system localization, this is a bug leading to missing translations (falling back to English). This PR solves this by implementing an easy way to remove all fuzzy tags.